### PR TITLE
Fix compiler warning on GCC 5.1.0

### DIFF
--- a/double-conversion/bignum.cc
+++ b/double-conversion/bignum.cc
@@ -104,7 +104,7 @@ void Bignum::AssignDecimalString(Vector<const char> value) {
   const int kMaxUint64DecimalDigits = 19;
   Zero();
   int length = value.length();
-  int pos = 0;
+  unsigned int pos = 0;
   // Let's just say that each digit needs 4 bits.
   while (length >= kMaxUint64DecimalDigits) {
     uint64_t digits = ReadUInt64(value, pos, kMaxUint64DecimalDigits);


### PR DESCRIPTION
I've gotten a number of reports on this in a project that vendors double-conversion. I've pasted an example of compiling with -Werror below. The fix is straight forward.

<pre>
==> jiffy (compile)
...
Compiling c_src/double-conversion/bignum.cc
c_src/double-conversion/bignum.cc: In member function ‘void double_conversion::Bignum::AssignDecimalString(double_conversion::Vector<const char>)’:
c_src/double-conversion/bignum.cc:101:6: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Werror=strict-overflow]
 void Bignum::AssignDecimalString(Vector<const char> value) {
      ^
cc1plus: all warnings being treated as errors
ERROR: c++ -c  -g -Wall -Werror -O3 -g -Wall -fPIC  -I/usr/lib/erlang/lib/erl_interface-3.7.20/include -I/usr/lib/erlang/erts-6.4/include   c_src/double-conversion/bignum.cc -o c_src/double-conversion/bignum.o failed with error: 1 and output:
c_src/double-conversion/bignum.cc: In member function ‘void double_conversion::Bignum::AssignDecimalString(double_conversion::Vector<const char>)’:
c_src/double-conversion/bignum.cc:101:6: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Werror=strict-overflow]
 void Bignum::AssignDecimalString(Vector<const char> value) {
      ^
cc1plus: all warnings being treated as errors
</pre>

<pre>
gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-unknown-linux-gnu/5.1.0/lto-wrapper
Target: x86_64-unknown-linux-gnu
Configured with: /build/gcc-multilib/src/gcc-5.1.0/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --with-system-zlib --with-isl --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --disable-libssp --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-install-libiberty --with-linker-hash-style=gnu --enable-gnu-indirect-function --enable-multilib --disable-werror --with-multilib-list=m32,m64,mx32 --enable-checking=release --enable-libmpx --with-default-libstdcxx-abi=c++98
Thread model: posix
gcc version 5.1.0 (GCC)
</pre>