### PR TITLE
fixed inconsistent include paths

### DIFF
--- a/double-conversion/bignum-dtoa.h
+++ b/double-conversion/bignum-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_BIGNUM_DTOA_H_
 #define DOUBLE_CONVERSION_BIGNUM_DTOA_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/bignum.cc
+++ b/double-conversion/bignum.cc
@@ -25,8 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "double-conversion/bignum.h"
-#include "double-conversion/utils.h"
+#include "bignum.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/bignum.h
+++ b/double-conversion/bignum.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_BIGNUM_H_
 #define DOUBLE_CONVERSION_BIGNUM_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/cached-powers.cc
+++ b/double-conversion/cached-powers.cc
@@ -29,7 +29,7 @@
 #include <limits.h>
 #include <math.h>
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 #include "cached-powers.h"
 

--- a/double-conversion/diy-fp.cc
+++ b/double-conversion/diy-fp.cc
@@ -26,8 +26,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#include "double-conversion/diy-fp.h"
-#include "double-conversion/utils.h"
+#include "diy-fp.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/diy-fp.h
+++ b/double-conversion/diy-fp.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_DIY_FP_H_
 #define DOUBLE_CONVERSION_DIY_FP_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/double-conversion.cc
+++ b/double-conversion/double-conversion.cc
@@ -28,14 +28,14 @@
 #include <limits.h>
 #include <math.h>
 
-#include "double-conversion/double-conversion.h"
+#include "double-conversion.h"
 
-#include "double-conversion/bignum-dtoa.h"
-#include "double-conversion/fast-dtoa.h"
-#include "double-conversion/fixed-dtoa.h"
-#include "double-conversion/ieee.h"
-#include "double-conversion/strtod.h"
-#include "double-conversion/utils.h"
+#include "bignum-dtoa.h"
+#include "fast-dtoa.h"
+#include "fixed-dtoa.h"
+#include "ieee.h"
+#include "strtod.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/double-conversion.h
+++ b/double-conversion/double-conversion.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_DOUBLE_CONVERSION_H_
 #define DOUBLE_CONVERSION_DOUBLE_CONVERSION_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/fast-dtoa.h
+++ b/double-conversion/fast-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_FAST_DTOA_H_
 #define DOUBLE_CONVERSION_FAST_DTOA_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/fixed-dtoa.h
+++ b/double-conversion/fixed-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_FIXED_DTOA_H_
 #define DOUBLE_CONVERSION_FIXED_DTOA_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/double-conversion/strtod.h
+++ b/double-conversion/strtod.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_STRTOD_H_
 #define DOUBLE_CONVERSION_STRTOD_H_
 
-#include "double-conversion/utils.h"
+#include "utils.h"
 
 namespace double_conversion {
 


### PR DESCRIPTION
fixed inconsistent include paths
also, fixed compile error when library is included with the root to double-conversion source folder