### PR TITLE
set cmake include directories at target level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,6 @@ foreach(p LIB BIN INCLUDE CMAKE)
   endif()
 endforeach()
 
-#
-# set up include dirs
-include_directories("${PROJECT_SOURCE_DIR}"
-  "${PROJECT_BINARY_DIR}"
-  )
-
 # Add src subdirectory
 add_subdirectory(double-conversion)
 

--- a/double-conversion/CMakeLists.txt
+++ b/double-conversion/CMakeLists.txt
@@ -23,6 +23,8 @@ strtod.cc
 ${headers}
 )
 
+target_include_directories(double-conversion PUBLIC ..)
+
 #
 # associates the list of headers with the library
 # for the purposes of installation/import into other projects


### PR DESCRIPTION
Not a big deal but with this change, one can just "git clone && add_subdirectory" to import double-conversion in another cmake solution.
Without it one need to add 
```cmake
target_include_directories(double-conversion PUBLIC $<BUILD_INTERFACE:${path_to_clone}>)
```

NB: I did not get the point of PROJECT_BINARY_DIR in removed cmake call
