### PR TITLE
fix cmake include directories at target level

### DIFF
--- a/double-conversion/CMakeLists.txt
+++ b/double-conversion/CMakeLists.txt
@@ -23,7 +23,7 @@ strtod.cc
 ${headers}
 )
 
-target_include_directories(double-conversion PUBLIC ..)
+target_include_directories(double-conversion PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
 #
 # associates the list of headers with the library


### PR DESCRIPTION
prevent a "which is prefixed in the build directory" error
by providing a full path and setting only for BUILD_INTERFACE
to avoid conflict with cmake's install call below

see https://github.com/google/double-conversion/pull/19 post merge discussion