### PR TITLE
remove code with no effect

### DIFF
--- a/double-conversion/double-conversion.cc
+++ b/double-conversion/double-conversion.cc
@@ -125,8 +125,6 @@ void DoubleToStringConverter::CreateDecimalRepresentation(
       result_builder->AddPadding('0', -decimal_point);
       ASSERT(length <= digits_after_point - (-decimal_point));
       result_builder->AddSubstring(decimal_digits, length);
-      int remaining_digits = digits_after_point - (-decimal_point) - length;
-      result_builder->AddPadding('0', remaining_digits);
     }
   } else if (decimal_point >= length) {
     // "decimal_rep0000.00000" or "decimal_rep.0000"


### PR DESCRIPTION
In DoubleToStringConverter::CreateDecimalRepresentation the branch with ``decimal_point <= 0`` calculates ``remaining_digits``, which is apparently identical to zero given ``digits_after_point > 0``:
``digits_after_point = length - decimal_point > 0``, thus ``remaining_digits = digits_after_point - (-decimal_point) - length = length - decimal_point - (-decimal_point) - length = 0``.
It also contradicts the commentary which shows ``decimal_rep`` being appended with no zeroes.