### PR TITLE
add WORKSPACE file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+# Bazel (http://bazel.io/) WORKSPACE file for double-conversion.


### PR DESCRIPTION
This is necessary in order to build with Bazel.

Tested on Linux with the following command line:

$ bazel build //:all

For #11.