### PR TITLE
Update Visual Studio 2013 project files.

### DIFF
--- a/msvc/double-conversion.vcxproj
+++ b/msvc/double-conversion.vcxproj
@@ -147,26 +147,26 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\bignum-dtoa.cc" />
-    <ClCompile Include="..\src\bignum.cc" />
-    <ClCompile Include="..\src\cached-powers.cc" />
-    <ClCompile Include="..\src\diy-fp.cc" />
-    <ClCompile Include="..\src\double-conversion.cc" />
-    <ClCompile Include="..\src\fast-dtoa.cc" />
-    <ClCompile Include="..\src\fixed-dtoa.cc" />
-    <ClCompile Include="..\src\strtod.cc" />
+    <ClCompile Include="..\double-conversion\bignum-dtoa.cc" />
+    <ClCompile Include="..\double-conversion\bignum.cc" />
+    <ClCompile Include="..\double-conversion\cached-powers.cc" />
+    <ClCompile Include="..\double-conversion\diy-fp.cc" />
+    <ClCompile Include="..\double-conversion\double-conversion.cc" />
+    <ClCompile Include="..\double-conversion\fast-dtoa.cc" />
+    <ClCompile Include="..\double-conversion\fixed-dtoa.cc" />
+    <ClCompile Include="..\double-conversion\strtod.cc" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\bignum-dtoa.h" />
-    <ClInclude Include="..\src\bignum.h" />
-    <ClInclude Include="..\src\cached-powers.h" />
-    <ClInclude Include="..\src\diy-fp.h" />
-    <ClInclude Include="..\src\double-conversion.h" />
-    <ClInclude Include="..\src\fast-dtoa.h" />
-    <ClInclude Include="..\src\fixed-dtoa.h" />
-    <ClInclude Include="..\src\ieee.h" />
-    <ClInclude Include="..\src\strtod.h" />
-    <ClInclude Include="..\src\utils.h" />
+    <ClInclude Include="..\double-conversion\bignum-dtoa.h" />
+    <ClInclude Include="..\double-conversion\bignum.h" />
+    <ClInclude Include="..\double-conversion\cached-powers.h" />
+    <ClInclude Include="..\double-conversion\diy-fp.h" />
+    <ClInclude Include="..\double-conversion\double-conversion.h" />
+    <ClInclude Include="..\double-conversion\fast-dtoa.h" />
+    <ClInclude Include="..\double-conversion\fixed-dtoa.h" />
+    <ClInclude Include="..\double-conversion\ieee.h" />
+    <ClInclude Include="..\double-conversion\strtod.h" />
+    <ClInclude Include="..\double-conversion\utils.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc/double-conversion.vcxproj.filters
+++ b/msvc/double-conversion.vcxproj.filters
@@ -15,60 +15,60 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\bignum.cc">
+    <ClCompile Include="..\double-conversion\bignum.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\bignum-dtoa.cc">
+    <ClCompile Include="..\double-conversion\bignum-dtoa.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\cached-powers.cc">
+    <ClCompile Include="..\double-conversion\cached-powers.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\diy-fp.cc">
+    <ClCompile Include="..\double-conversion\diy-fp.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\double-conversion.cc">
+    <ClCompile Include="..\double-conversion\double-conversion.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\fast-dtoa.cc">
+    <ClCompile Include="..\double-conversion\fast-dtoa.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\fixed-dtoa.cc">
+    <ClCompile Include="..\double-conversion\fixed-dtoa.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\strtod.cc">
+    <ClCompile Include="..\double-conversion\strtod.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\bignum.h">
+    <ClInclude Include="..\double-conversion\bignum.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\bignum-dtoa.h">
+    <ClInclude Include="..\double-conversion\bignum-dtoa.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\cached-powers.h">
+    <ClInclude Include="..\double-conversion\cached-powers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\diy-fp.h">
+    <ClInclude Include="..\double-conversion\diy-fp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\double-conversion.h">
+    <ClInclude Include="..\double-conversion\double-conversion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\fast-dtoa.h">
+    <ClInclude Include="..\double-conversion\fast-dtoa.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\fixed-dtoa.h">
+    <ClInclude Include="..\double-conversion\fixed-dtoa.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\ieee.h">
+    <ClInclude Include="..\double-conversion\ieee.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\strtod.h">
+    <ClInclude Include="..\double-conversion\strtod.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\utils.h">
+    <ClInclude Include="..\double-conversion\utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/double-conversion.vcxproj.user
+++ b/msvc/double-conversion.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/msvc/run_tests/run_tests.vcxproj
+++ b/msvc/run_tests/run_tests.vcxproj
@@ -94,6 +94,7 @@
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/run_tests/run_tests.vcxproj
+++ b/msvc/run_tests/run_tests.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -107,7 +107,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -123,7 +123,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,7 +141,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
* Fix error C1128 for x86 debug builds.
The test\cctest\gay-precision.cc file will cause below error
for Visual Studio 2013.
`fatal error C1128: number of sections exceeded
object file format limit : compile with /bigobj`

* Use correct file paths.
The Visual Studio project files has outdated file paths.
 
* Remove user specific project file.
The *.vcxporj.user file should not be included in code repository.