### PR TITLE
Add Bazel rules for running tests.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,7 @@ cc_library(
     "double-conversion/double-conversion.h",
     "double-conversion/fast-dtoa.h",
     "double-conversion/fixed-dtoa.h",
-    "double-conversion/ieee.h", 
+    "double-conversion/ieee.h",
     "double-conversion/strtod.h",
   ],
   srcs = [
@@ -32,5 +32,44 @@ cc_library(
   ],
   linkopts = [
     "-lm",
+  ]
+)
+
+cc_test(
+  name = "cctest",
+  visibility = ["//visibility:public"],
+  deps = [":double-conversion"],
+  srcs = [
+    "test/cctest/cctest.cc",
+    "test/cctest/cctest.h",
+    "test/cctest/checks.h",
+    "test/cctest/gay-fixed.cc",
+    "test/cctest/gay-fixed.h",
+    "test/cctest/gay-precision.cc",
+    "test/cctest/gay-precision.h",
+    "test/cctest/gay-shortest.cc",
+    "test/cctest/gay-shortest.h",
+    "test/cctest/gay-shortest-single.cc",
+    "test/cctest/gay-shortest-single.h",
+    "test/cctest/test-bignum.cc",
+    "test/cctest/test-bignum-dtoa.cc",
+    "test/cctest/test-conversions.cc",
+    "test/cctest/test-diy-fp.cc",
+    "test/cctest/test-dtoa.cc",
+    "test/cctest/test-fast-dtoa.cc",
+    "test/cctest/test-fixed-dtoa.cc",
+    "test/cctest/test-ieee.cc",
+    "test/cctest/test-strtod.cc"
+  ],
+  args = [
+    "test-bignum",
+    "test-bignum-dtoa",
+    "test-conversions",
+    "test-diy-fp",
+    "test-dtoa",
+    "test-fast-dtoa",
+    "test-fixed-dtoa",
+    "test-ieee",
+    "test-strtod"
   ]
 )


### PR DESCRIPTION
Tested on Linux with the following commands:

  $ mkdir test-double-conversion
  $ cd test-double-conversion
  $ touch WORKSPACE
  $ ln -s <path to double-conversion>
  $ bazel test //double-conversion:all