### PR TITLE
fix Bazel's "includes" attribute error

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,9 +27,6 @@ cc_library(
     "double-conversion/strtod.cc",
     "double-conversion/utils.h"
   ],
-  includes = [
-    ".",
-  ],
   linkopts = [
     "-lm",
   ]


### PR DESCRIPTION
This should allow the following command line to work again:

$ bazel build //...