### PR TITLE
Add fPIC flag on x86_64 if the compiler supports it.

### DIFF
--- a/double-conversion/CMakeLists.txt
+++ b/double-conversion/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(headers
   bignum.h
   cached-powers.h
@@ -24,6 +23,14 @@ ${headers}
 )
 
 target_include_directories(double-conversion PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+
+# Add fPIC on x86_64 when supported.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fPIC CXX_HAS_FPIC)
+
+if(CXX_HAS_FPIC AND CMAKE_SYSTEM_PROCESSOER STREQUAL "x86_64")
+  set_target_properties(double-conversion PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
 
 #
 # associates the list of headers with the library


### PR DESCRIPTION
Fixes #34.