### PR TITLE
Avoid negative shift.

### DIFF
--- a/double-conversion/fixed-dtoa.cc
+++ b/double-conversion/fixed-dtoa.cc
@@ -259,7 +259,7 @@ static void FillFractionals(uint64_t fractionals, int exponent,
       fractionals -= static_cast<uint64_t>(digit) << point;
     }
     // If the first bit after the point is set we have to round up.
-    if (((fractionals >> (point - 1)) & 1) == 1) {
+    if ((fractionals != 0) && ((fractionals >> (point - 1)) & 1) == 1) {
       RoundUp(buffer, length, decimal_point);
     }
   } else {  // We need 128 bits.

--- a/double-conversion/fixed-dtoa.cc
+++ b/double-conversion/fixed-dtoa.cc
@@ -259,6 +259,7 @@ static void FillFractionals(uint64_t fractionals, int exponent,
       fractionals -= static_cast<uint64_t>(digit) << point;
     }
     // If the first bit after the point is set we have to round up.
+    ASSERT(fractionals == 0 || point - 1 >= 0);
     if ((fractionals != 0) && ((fractionals >> (point - 1)) & 1) == 1) {
       RoundUp(buffer, length, decimal_point);
     }

--- a/test/cctest/test-fixed-dtoa.cc
+++ b/test/cctest/test-fixed-dtoa.cc
@@ -485,6 +485,10 @@ TEST(FastFixedVariousDoubles) {
                       buffer, &length, &point));
   CHECK_EQ("1000000000000000128", buffer.start());
   CHECK_EQ(19, point);
+
+  CHECK(FastFixedDtoa(2.10861548515811875e+15, 17, buffer, &length, &point));
+  CHECK_EQ("210861548515811875", buffer.start());
+  CHECK_EQ(16, point);
 }
 
 


### PR DESCRIPTION
When filling in fractional digits in a fixed representation we
might use all existing digits. When this happens, we can not look
at the next digit to see if we should round up.

Before this fix, we tried to shift by a negative amount to see if the
(non-existing) next bit was set to 1 (requiring the number to be rounded up).

Fixes #41.