### PR TITLE
Enable other programs to include headers using `<>`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,9 @@ cc_library(
         "double-conversion/ieee.h",
         "double-conversion/strtod.h",
     ],
+    includes = [
+        ".",
+    ],
     linkopts = [
         "-lm",
     ],


### PR DESCRIPTION
This modification enable other programs to include this library headers with '#include <>'.