### PR TITLE
Clarify output charset in DoubleToAscii documentation

### DIFF
--- a/double-conversion/double-conversion.h
+++ b/double-conversion/double-conversion.h
@@ -294,12 +294,17 @@ class DoubleToStringConverter {
   // should be at least kBase10MaximalLength + 1 characters long.
   static const int kBase10MaximalLength = 17;
 
-  // Converts the given double 'v' to ascii. 'v' must not be NaN, +Infinity, or
-  // -Infinity. In SHORTEST_SINGLE-mode this restriction also applies to 'v'
-  // after it has been casted to a single-precision float. That is, in this
-  // mode static_cast<float>(v) must not be NaN, +Infinity or -Infinity.
+  // Converts the given double 'v' to digit characters. 'v' must not be NaN,
+  // +Infinity, or -Infinity. In SHORTEST_SINGLE-mode this restriction also
+  // applies to 'v' after it has been casted to a single-precision float. That
+  // is, in this mode static_cast<float>(v) must not be NaN, +Infinity or
+  // -Infinity.
   //
   // The result should be interpreted as buffer * 10^(point-length).
+  //
+  // The digits are written to the buffer in the platform's charset, which is
+  // often UTF-8 (ASCII-range for digits), but may be anoter charset, such as
+  // EBCDIC.
   //
   // The output depends on the given mode:
   //  - SHORTEST: produce the least amount of digits for which the internal

--- a/double-conversion/double-conversion.h
+++ b/double-conversion/double-conversion.h
@@ -303,8 +303,8 @@ class DoubleToStringConverter {
   // The result should be interpreted as buffer * 10^(point-length).
   //
   // The digits are written to the buffer in the platform's charset, which is
-  // often UTF-8 (ASCII-range for digits), but may be anoter charset, such as
-  // EBCDIC.
+  // often UTF-8 (with ASCII-range digits) but may be another charset, such
+  // as EBCDIC.
   //
   // The output depends on the given mode:
   //  - SHORTEST: produce the least amount of digits for which the internal


### PR DESCRIPTION
From looking at the code, it appears that functions such as those in fast_dtoa.cc write characters to the buffer relative to '0'.  That character is usually ASCII 0 (0x30, U+0030), but on certain platforms, such as those that use EBCDIC instead of ASCII, the literal `'0'` maps to a different char value.

The function `DoubleToAscii` should probably be named `DoubleToChars`, but good documentation should be sufficient without having to change the name of the function.