### PR TITLE
Add support of ARC architecture

### DIFF
--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
     defined(_MIPS_ARCH_MIPS32R2) || \
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || \
-    defined(__or1k__)
+    defined(__or1k__) || defined(__arc__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \
     defined(__pnacl__) || defined(__native_client__)


### PR DESCRIPTION
More info about ARC architecture is here: [1] & [2].
We need ARC supported here for many things like:
 - ICU (see [3])
 - Qt5 etc

[1] https://www.synopsys.com/designware-ip/processor-solutions/arc-processors.html
[2] https://en.wikipedia.org/wiki/ARC_(processor)
[3] https://unicode-org.atlassian.net/browse/ICU-20155

Fixes #81