### PR TITLE
CMake: install to correct lib dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,13 @@ endif()
 ####
 # Installation (https://github.com/forexample/package-example)
 
+include(GNUInstallDirs)
+
 # Layout. This works for all platforms:
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
@@ -81,17 +82,17 @@ configure_package_config_file(
 install(
     TARGETS double-conversion
     EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 # Headers:
 #   * double-conversion/*.h -> <prefix>/include/double-conversion/*.h
 install(
     FILES ${headers}
-    DESTINATION "${include_install_dir}/double-conversion"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/double-conversion"
 )
 
 # Config


### PR DESCRIPTION
64-bit libraries should be installed in /usr/lib64, not in /usr/lib/
Make the destination lib dir configurable.

Commit e13e72e17692f5dc0036460d734c637b563f3ac7 removed
include(GNUInstallDirs) and ${CMAKE_INSTALL_LIBDIR} which broke
installing on 64-bit systems.

Signed-off-by: Jason Zaman <jason@perfinion.com>