### PR TITLE
build fix for g++ 4.9.3

### DIFF
--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -56,6 +56,12 @@ inline void abort_noreturn() { abort(); }
 #endif
 #endif
 
+#ifdef __GNUC__
+#define DOUBLECONVERSION_UNUSED __attribute__((unused))
+#else
+#define DOUBLECONVERSION_UNUSED
+#endif
+
 
 // Double operations detection based on target architecture.
 // Linux uses a 80bit wide floating point stack on x86. This induces double
@@ -341,7 +347,7 @@ inline Dest BitCast(const Source& source) {
   static_assert(sizeof(Dest) == sizeof(Source),
                 "source and destination size mismatch");
 #else
-  typedef char VerifySizesAreEqual[sizeof(Dest) == sizeof(Source) ? 1 : -1];
+  DOUBLECONVERSION_UNUSED typedef char VerifySizesAreEqual[sizeof(Dest) == sizeof(Source) ? 1 : -1];
 #endif
 
   Dest dest;


### PR DESCRIPTION
This fixes a warning that occurs with g++ 4.9.3 (which prevents compilation, since warnings are treated as errors). Another solution is to compile with -std=c++11.