### PR TITLE
Use standard min/max.

### DIFF
--- a/double-conversion/bignum.cc
+++ b/double-conversion/bignum.cc
@@ -25,6 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <algorithm>
+
 #include "bignum.h"
 #include "utils.h"
 
@@ -186,7 +188,7 @@ void Bignum::AddBignum(const Bignum& other) {
   //  cccccccccccc 0000
   // In both cases we might need a carry bigit.
 
-  EnsureCapacity(1 + Max(BigitLength(), other.BigitLength()) - exponent_);
+  EnsureCapacity(1 + (std::max)(BigitLength(), other.BigitLength()) - exponent_);
   Chunk carry = 0;
   int bigit_pos = other.exponent_ - exponent_;
   ASSERT(bigit_pos >= 0);
@@ -203,7 +205,7 @@ void Bignum::AddBignum(const Bignum& other) {
     carry = sum >> kBigitSize;
     bigit_pos++;
   }
-  used_digits_ = Max(bigit_pos, used_digits_);
+  used_digits_ = (std::max)(bigit_pos, used_digits_);
   ASSERT(IsClamped());
 }
 
@@ -623,7 +625,7 @@ int Bignum::Compare(const Bignum& a, const Bignum& b) {
   int bigit_length_b = b.BigitLength();
   if (bigit_length_a < bigit_length_b) return -1;
   if (bigit_length_a > bigit_length_b) return +1;
-  for (int i = bigit_length_a - 1; i >= Min(a.exponent_, b.exponent_); --i) {
+  for (int i = bigit_length_a - 1; i >= (std::min)(a.exponent_, b.exponent_); --i) {
     Chunk bigit_a = a.BigitAt(i);
     Chunk bigit_b = b.BigitAt(i);
     if (bigit_a < bigit_b) return -1;
@@ -652,7 +654,7 @@ int Bignum::PlusCompare(const Bignum& a, const Bignum& b, const Bignum& c) {
 
   Chunk borrow = 0;
   // Starting at min_exponent all digits are == 0. So no need to compare them.
-  int min_exponent = Min(Min(a.exponent_, b.exponent_), c.exponent_);
+  int min_exponent = (std::min)((std::min)(a.exponent_, b.exponent_), c.exponent_);
   for (int i = c.BigitLength() - 1; i >= min_exponent; --i) {
     Chunk chunk_a = a.BigitAt(i);
     Chunk chunk_b = b.BigitAt(i);

--- a/double-conversion/double-conversion.cc
+++ b/double-conversion/double-conversion.cc
@@ -25,6 +25,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <algorithm>
 #include <climits>
 #include <locale>
 #include <cmath>
@@ -187,7 +188,7 @@ bool DoubleToStringConverter::ToShortestIeeeNumber(
       (exponent < decimal_in_shortest_high_)) {
     CreateDecimalRepresentation(decimal_rep, decimal_rep_length,
                                 decimal_point,
-                                Max(0, decimal_rep_length - decimal_point),
+                                (std::max)(0, decimal_rep_length - decimal_point),
                                 result_builder);
   } else {
     CreateExponentialRepresentation(decimal_rep, decimal_rep_length, exponent,
@@ -338,7 +339,7 @@ bool DoubleToStringConverter::ToPrecision(double value,
                                     result_builder);
   } else {
     CreateDecimalRepresentation(decimal_rep, decimal_rep_length, decimal_point,
-                                Max(0, precision - decimal_point),
+                                (std::max)(0, precision - decimal_point),
                                 result_builder);
   }
   return true;

--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -178,20 +178,6 @@ namespace double_conversion {
 
 static const int kCharSize = sizeof(char);
 
-// Returns the maximum of the two parameters.
-template <typename T>
-static T Max(T a, T b) {
-  return a < b ? b : a;
-}
-
-
-// Returns the minimum of the two parameters.
-template <typename T>
-static T Min(T a, T b) {
-  return a < b ? a : b;
-}
-
-
 inline int StrLength(const char* string) {
   size_t length = strlen(string);
   ASSERT(length == static_cast<size_t>(static_cast<int>(length)));


### PR DESCRIPTION
(With the usual additional brackets to prevent interference with macros named min/max on Windows.)