### PR TITLE
Add wasm32 as supported platform

### DIFF
--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
     defined(__riscv) || defined(__e2k__) || \
     defined(__or1k__) || defined(__arc__) || \
     defined(__microblaze__) || defined(__XTENSA__) || \
-    defined(__EMSCRIPTEN__)
+    defined(__EMSCRIPTEN__) || defined(__wasm32__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \
     defined(__pnacl__) || defined(__native_client__)


### PR DESCRIPTION
Summary:
Emscripten is already included, adding wasm32 the same way when
building with "plain" clang wasm32 (without emscripten)

Test Plan:
make
test/cctest/cctest --list | tr -d '<' | xargs test/cctest/cctest

Reviewers:

Subscribers:

Tasks:

Tags: