### PR TITLE
Fix strtod.cc undefined constants

### DIFF
--- a/double-conversion/strtod.cc
+++ b/double-conversion/strtod.cc
@@ -35,10 +35,12 @@
 
 namespace double_conversion {
 
+#if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 // 2^53 = 9007199254740992.
 // Any integer with at most 15 decimal digits will hence fit into a double
 // (which has a 53bit significand) without loss of precision.
 static const int kMaxExactDoubleIntegerDecimalDigits = 15;
+#endif // #if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 // 2^64 = 18446744073709551616 > 10^19
 static const int kMaxUint64DecimalDigits = 19;
 
@@ -55,6 +57,7 @@ static const int kMinDecimalPower = -324;
 static const uint64_t kMaxUint64 = DOUBLE_CONVERSION_UINT64_2PART_C(0xFFFFFFFF, FFFFFFFF);
 
 
+#if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 static const double exact_powers_of_ten[] = {
   1.0,  // 10^0
   10.0,
@@ -82,6 +85,7 @@ static const double exact_powers_of_ten[] = {
   10000000000000000000000.0
 };
 static const int kExactPowersOfTenSize = DOUBLE_CONVERSION_ARRAY_SIZE(exact_powers_of_ten);
+#endif // #if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 
 // Maximum number of significant digits in the decimal representation.
 // In fact the value is 772 (see conversions.cc), but to give us some margin


### PR DESCRIPTION
When DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS is not defined
there is a build error when -Wall -Werror enabled because
kMaxExactDoubleIntegerDecimalDigits, exact_powers_of_ten and
kExactPowersOfTenSize are used only in else branch of this define
(when it's defined).

Fixes https://github.com/google/double-conversion/issues/122