### PR TITLE
Move buffer and buffer_pos down

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -551,7 +551,8 @@ double StringToDoubleConverter::StringToIeee(
 
   // The longest form of simplified number is: "-<significant digits>.1eXXX\0".
   const int kBufferSize = kMaxSignificantDigits + 10;
-  char buffer[kBufferSize];  // NOLINT: size is known at compile time.
+  DOUBLE_CONVERSION_STACK_UNINITIALIZED char
+      buffer[kBufferSize];  // NOLINT: size is known at compile time.
   int buffer_pos = 0;
 
   // Copy significant digits of the integer part (if any) to the buffer.

--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -441,11 +441,6 @@ double StringToDoubleConverter::StringToIeee(
     }
   }
 
-  // The longest form of simplified number is: "-<significant digits>.1eXXX\0".
-  const int kBufferSize = kMaxSignificantDigits + 10;
-  char buffer[kBufferSize];  // NOLINT: size is known at compile time.
-  int buffer_pos = 0;
-
   // Exponent will be adjusted if insignificant digits of the integer part
   // or insignificant leading zeros of the fractional part are dropped.
   int exponent = 0;
@@ -480,7 +475,6 @@ double StringToDoubleConverter::StringToIeee(
         return junk_string_value_;
       }
 
-      DOUBLE_CONVERSION_ASSERT(buffer_pos == 0);
       *processed_characters_count = static_cast<int>(current - input);
       return sign ? -Double::Infinity() : Double::Infinity();
     }
@@ -499,7 +493,6 @@ double StringToDoubleConverter::StringToIeee(
         return junk_string_value_;
       }
 
-      DOUBLE_CONVERSION_ASSERT(buffer_pos == 0);
       *processed_characters_count = static_cast<int>(current - input);
       return sign ? -Double::NaN() : Double::NaN();
     }
@@ -555,6 +548,11 @@ double StringToDoubleConverter::StringToIeee(
   }
 
   bool octal = leading_zero && (flags_ & ALLOW_OCTALS) != 0;
+
+  // The longest form of simplified number is: "-<significant digits>.1eXXX\0".
+  const int kBufferSize = kMaxSignificantDigits + 10;
+  char buffer[kBufferSize];  // NOLINT: size is known at compile time.
+  int buffer_pos = 0;
 
   // Copy significant digits of the integer part (if any) to the buffer.
   while (*current >= '0' && *current <= '9') {

--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -64,6 +64,12 @@ inline void abort_noreturn() { abort(); }
 #endif
 #endif
 
+#if defined(__clang__) && __has_attribute(uninitialized)
+#define DOUBLE_CONVERSION_STACK_UNINITIALIZED __attribute__((uninitialized))
+#else
+#define DOUBLE_CONVERSION_STACK_UNINITIALIZED
+#endif
+
 // Double operations detection based on target architecture.
 // Linux uses a 80bit wide floating point stack on x86. This induces double
 // rounding, which in turn leads to wrong results.


### PR DESCRIPTION
Simplifies code by removing two asserts
Optimize code with -ftrivial-auto-var-init=pattern by avoiding initialization when buffer is not used

Related bug https://bugs.chromium.org/p/chromium/issues/detail?id=977230