### PR TITLE
Fix broken MSVC builds.

### DIFF
--- a/msvc/double-conversion.vcxproj
+++ b/msvc/double-conversion.vcxproj
@@ -147,24 +147,25 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\double-conversion\bignum-dtoa.cc" />
     <ClCompile Include="..\double-conversion\bignum.cc" />
+    <ClCompile Include="..\double-conversion\bignum-dtoa.cc" />
     <ClCompile Include="..\double-conversion\cached-powers.cc" />
-    <ClCompile Include="..\double-conversion\diy-fp.cc" />
-    <ClCompile Include="..\double-conversion\double-conversion.cc" />
+    <ClCompile Include="..\double-conversion\double-to-string.cc" />
     <ClCompile Include="..\double-conversion\fast-dtoa.cc" />
     <ClCompile Include="..\double-conversion\fixed-dtoa.cc" />
+    <ClCompile Include="..\double-conversion\string-to-double.cc" />
     <ClCompile Include="..\double-conversion\strtod.cc" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\double-conversion\bignum-dtoa.h" />
     <ClInclude Include="..\double-conversion\bignum.h" />
     <ClInclude Include="..\double-conversion\cached-powers.h" />
     <ClInclude Include="..\double-conversion\diy-fp.h" />
     <ClInclude Include="..\double-conversion\double-conversion.h" />
+    <ClInclude Include="..\double-conversion\double-to-string.h" />
     <ClInclude Include="..\double-conversion\fast-dtoa.h" />
     <ClInclude Include="..\double-conversion\fixed-dtoa.h" />
     <ClInclude Include="..\double-conversion\ieee.h" />
+    <ClInclude Include="..\double-conversion\string-to-double.h" />
     <ClInclude Include="..\double-conversion\strtod.h" />
     <ClInclude Include="..\double-conversion\utils.h" />
   </ItemGroup>

--- a/msvc/double-conversion.vcxproj.filters
+++ b/msvc/double-conversion.vcxproj.filters
@@ -24,12 +24,6 @@
     <ClCompile Include="..\double-conversion\cached-powers.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\double-conversion\diy-fp.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\double-conversion\double-conversion.cc">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\double-conversion\fast-dtoa.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -39,12 +33,15 @@
     <ClCompile Include="..\double-conversion\strtod.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\double-conversion\double-to-string.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\double-conversion\string-to-double.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\double-conversion\bignum.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\double-conversion\bignum-dtoa.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\double-conversion\cached-powers.h">
@@ -69,6 +66,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\double-conversion\utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\double-conversion\double-to-string.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\double-conversion\string-to-double.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/run_tests/run_tests.vcxproj
+++ b/msvc/run_tests/run_tests.vcxproj
@@ -109,6 +109,7 @@
       <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..</AdditionalIncludeDirectories>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Hello!

I was trying to get the project to build with MSVC using Visual Studio, but it looks like some files have been moved around and the existing `*.vcxproj` files are a bit stale. It appears as though the change in #104 renamed/moved files around, but the VS projects weren't updated.

This change fixes the existing `*.vcxproj` files in order to unblock building/compiling with MSVC via Visual Studio.

Thanks!