### PR TITLE
Add DOUBLE_CONVERSION_HAS_ATTRIBUTE to fix MSVC warnings, and enable for GCCbl…

### DIFF
--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -56,15 +56,23 @@ inline void abort_noreturn() { abort(); }
 #endif
 #endif
 
+// Not all compilers support __has_attribute and combining a check for both
+// ifdef and __has_attribute on the same preprocessor line isn't portable.
+#ifdef __has_attribute
+#   define DOUBLE_CONVERSION_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#   define DOUBLE_CONVERSION_HAS_ATTRIBUTE(x) 0
+#endif
+
 #ifndef DOUBLE_CONVERSION_UNUSED
-#ifdef __GNUC__
+#if DOUBLE_CONVERSION_HAS_ATTRIBUTE(unused)
 #define DOUBLE_CONVERSION_UNUSED __attribute__((unused))
 #else
 #define DOUBLE_CONVERSION_UNUSED
 #endif
 #endif
 
-#if defined(__clang__) && __has_attribute(uninitialized)
+#if DOUBLE_CONVERSION_HAS_ATTRIBUTE(uninitialized)
 #define DOUBLE_CONVERSION_STACK_UNINITIALIZED __attribute__((uninitialized))
 #else
 #define DOUBLE_CONVERSION_STACK_UNINITIALIZED


### PR DESCRIPTION
This fixes #129 and enables the macro `DOUBLE_CONVERSION_UNUSED` for Clang.

Details:
The following warning occurs 22 times when building with MSVC using VS2017 or VS2019:
```
utils.h(67,42): warning C4067: unexpected tokens following preprocessor directive - expected a newline
```

Based on reading the compiler documentation for GCC, it seems that combining the check for `ifdef` and `__has_attribute` in the same preprocessor line is not portable.

Additionally, the current code only conditionally enables this for Clang:

```c++
#if defined(__clang__) && __has_attribute(uninitialized)
#define DOUBLE_CONVERSION_STACK_UNINITIALIZED __attribute__((uninitialized))
#else
#define DOUBLE_CONVERSION_STACK_UNINITIALIZED
#endif
```

However, newer versions of GCC also support the `__has_attribute` special operator as well.
(See: https://gcc.gnu.org/onlinedocs/gcc-9.1.0/cpp/_005f_005fhas_005fattribute.html)

If we change this then we can fix both the warnings on MSVC and also enable this for GCC as well.

(The total warnings when building with MSVC is reduced from 47 warnings to 25 warnings.)
