### PR TITLE
Add /bigobj for MSVC tests

### DIFF
--- a/test/cctest/CMakeLists.txt
+++ b/test/cctest/CMakeLists.txt
@@ -18,6 +18,9 @@ set(CCTEST_SRC
 
 add_executable(cctest ${CCTEST_SRC})
 target_link_libraries(cctest double-conversion)
+if(MSVC)
+    target_compile_options(cctest PRIVATE /bigobj)
+endif()
 
 add_test(NAME test_bignum
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
On MSVC with Visual Studio 2017 and 2019, I get errors when building the tests because the number of sections in the object file is exceeded. I found that MSVC requires the compiler flag `/bigobj` to switch to a different storage format that allows a much larger number of sections.

As far as I know there is no downside to using this flag. Also, this PR introduces the change only for tests. Therefore this PR should not lead to any negative consequences for any users.