### PR TITLE
CMakeLists.txt: Export all symbols for MSVC shared library (DLL) build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(double-conversion VERSION 3.1.5)
 
+if(BUILD_SHARED_LIBS AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(headers
     double-conversion/bignum.h
     double-conversion/cached-powers.h


### PR DESCRIPTION
Currently the cmake based build creates shared libraries on MSVC that do not export any symbols. The shared library therefore has no import library (missing `double-conversion.lib`) and the shared library is basically 'empty' and can not be used for linking.

The clean solution on MSVC is to use the `declspec(dllexport)` and `declspec(dllexport)` keywords to correctly export symbols as required. But cmake offers a useful workaround that comes with virtually no downsides: The cmake setting WINDOWS_EXPORT_ALL_SYMBOLS (see https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html) can be used to export all symbols from a library. This is not as specific as the aforementioned solution based on `declspec(dllexport)` and `declspec(dllexport)`, but it allows a correct build and use of shared libraries on MSVC. The only downside is that more symbols may be exported than required.

This PR fixes a broken shared library on MSVC. It should not add any negative consequences for any other users.