### PR TITLE
Avoid unused function warning for AssertTrimmedDigits()

### DIFF
--- a/double-conversion/strtod.cc
+++ b/double-conversion/strtod.cc
@@ -460,6 +460,11 @@ static bool IsNonZeroDigit(const char d) {
   return ('1' <= d) && (d <= '9');
 }
 
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(maybe_unused)
+[[maybe_unused]]
+#endif
+#endif
 static bool AssertTrimmedDigits(const Vector<const char>& buffer) {
   for(int i = 0; i < buffer.length(); ++i) {
     if(!IsDigit(buffer[i])) {


### PR DESCRIPTION
It's only used in an assertion, hence it's unused when assertions are off.