### PR TITLE
Allow 100 decimal digits for 'toFixed'.

### DIFF
--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -38,7 +38,7 @@ class DoubleToStringConverter {
   // or a requested_digits parameter > kMaxFixedDigitsAfterPoint then the
   // function returns false.
   static const int kMaxFixedDigitsBeforePoint = 60;
-  static const int kMaxFixedDigitsAfterPoint = 60;
+  static const int kMaxFixedDigitsAfterPoint = 100;
 
   // When calling ToExponential with a requested_digits
   // parameter > kMaxExponentialDigits then the function returns false.

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -463,6 +463,10 @@ TEST(DoubleToFixed) {
 
   DOUBLE_CONVERSION_ASSERT(DoubleToStringConverter::kMaxFixedDigitsBeforePoint == 60);
   DOUBLE_CONVERSION_ASSERT(DoubleToStringConverter::kMaxFixedDigitsAfterPoint == 100);
+
+  // Most of the 100 digit tests were copied from
+  // https://searchfox.org/mozilla-central/source/js/src/tests/non262/Number/toFixed-values.js.
+
   builder.Reset();
   CHECK(dc.ToFixed(
       0.0, DoubleToStringConverter::kMaxFixedDigitsAfterPoint, &builder));
@@ -511,10 +515,45 @@ TEST(DoubleToFixed) {
            builder.Finalize());
 
   builder.Reset();
-  CHECK(dc.ToExponential(1.15,
+  CHECK(dc.ToFixed(3.141592653589793,
                    DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
                    &builder));
-  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011",
+  CHECK_EQ("3.1415926535897931159979634685441851615905761718750000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(1.0,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("1.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(-123456.78,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("-123456.7799999999988358467817306518554687500000000000000000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(123456.78,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("123456.7799999999988358467817306518554687500000000000000000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(100000000000000000000.0,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("100000000000000000000.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(-100000000000000000000.0,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("-100000000000000000000.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            builder.Finalize());
 
   builder.Reset();
@@ -670,6 +709,10 @@ TEST(DoubleToFixed) {
   builder.Reset();
   CHECK(dc5.ToFixed(0.1, 30, &builder));
   CHECK_EQ("0.100000000000000005551115123126", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc5.ToFixed(0.1, 100, &builder));
+  CHECK_EQ("0.1000000000000000055511151231257827021181583404541015625000000000000000000000000000000000000000000000", builder.Finalize());
 
   builder.Reset();
   CHECK(dc5.ToFixed(0.1, 17, &builder));

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -438,7 +438,7 @@ TEST(DoubleToShortestSingle) {
 
 
 TEST(DoubleToFixed) {
-  const int kBufferSize = 128;
+  const int kBufferSize = 168;
   char buffer[kBufferSize];
   StringBuilder builder(buffer, kBufferSize);
   int flags = DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN |
@@ -462,25 +462,59 @@ TEST(DoubleToFixed) {
   CHECK_EQ("0.0", builder.Finalize());
 
   DOUBLE_CONVERSION_ASSERT(DoubleToStringConverter::kMaxFixedDigitsBeforePoint == 60);
-  DOUBLE_CONVERSION_ASSERT(DoubleToStringConverter::kMaxFixedDigitsAfterPoint == 60);
+  DOUBLE_CONVERSION_ASSERT(DoubleToStringConverter::kMaxFixedDigitsAfterPoint == 100);
   builder.Reset();
   CHECK(dc.ToFixed(
       0.0, DoubleToStringConverter::kMaxFixedDigitsAfterPoint, &builder));
-  CHECK_EQ("0.000000000000000000000000000000000000000000000000000000000000",
+  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            builder.Finalize());
 
   builder.Reset();
   CHECK(dc.ToFixed(
       9e59, DoubleToStringConverter::kMaxFixedDigitsAfterPoint, &builder));
   CHECK_EQ("899999999999999918767229449717619953810131273674690656206848."
-           "000000000000000000000000000000000000000000000000000000000000",
+           "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            builder.Finalize());
 
   builder.Reset();
   CHECK(dc.ToFixed(
       -9e59, DoubleToStringConverter::kMaxFixedDigitsAfterPoint, &builder));
   CHECK_EQ("-899999999999999918767229449717619953810131273674690656206848."
-           "000000000000000000000000000000000000000000000000000000000000",
+           "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(
+      1e-100, DoubleToStringConverter::kMaxFixedDigitsAfterPoint, &builder));
+  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(0.3000000000000000444089209850062616169452667236328125,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("0.3000000000000000444089209850062616169452667236328125000000000000000000000000000000000000000000000000",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(1.5e-100,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToFixed(1.15e-99,  // In reality: 1.14999999999999992147301128036734...
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011",
+           builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToExponential(1.15,
+                   DoubleToStringConverter::kMaxFixedDigitsAfterPoint,
+                   &builder));
+  CHECK_EQ("0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011",
            builder.Finalize());
 
   builder.Reset();


### PR DESCRIPTION
Fixes #152.