### PR TITLE
Add `StringToDoubleConverter::StringTo<T>` member function templates

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -779,4 +779,40 @@ float StringToDoubleConverter::StringToFloat(
                                          processed_characters_count));
 }
 
+
+template<>
+double StringToDoubleConverter::StringTo<double>(
+    const char* buffer,
+    int length,
+    int* processed_characters_count) const {
+    return StringToDouble(buffer, length, processed_characters_count);
+}
+
+
+template<>
+float StringToDoubleConverter::StringTo<float>(
+    const char* buffer,
+    int length,
+    int* processed_characters_count) const {
+    return StringToFloat(buffer, length, processed_characters_count);
+}
+
+
+template<>
+double StringToDoubleConverter::StringTo<double>(
+    const uc16* buffer,
+    int length,
+    int* processed_characters_count) const {
+    return StringToDouble(buffer, length, processed_characters_count);
+}
+
+
+template<>
+float StringToDoubleConverter::StringTo<float>(
+    const uc16* buffer,
+    int length,
+    int* processed_characters_count) const {
+    return StringToFloat(buffer, length, processed_characters_count);
+}
+
 }  // namespace double_conversion

--- a/double-conversion/string-to-double.h
+++ b/double-conversion/string-to-double.h
@@ -204,6 +204,18 @@ class StringToDoubleConverter {
                       int length,
                       int* processed_characters_count) const;
 
+  // Same as StringToDouble for T = double, and StringToFloat for T = float.
+  template <typename T>
+  T StringTo(const char* buffer,
+             int length,
+             int* processed_characters_count) const;
+
+  // Same as StringTo above but for 16 bit characters.
+  template <typename T>
+  T StringTo(const uc16* buffer,
+             int length,
+             int* processed_characters_count) const;
+
  private:
   const int flags_;
   const double empty_string_value_;


### PR DESCRIPTION
Allowed users to write generic code more easily, like this (when `T` is
either `float` or `double`):

    converter.StringTo<T>(buffer, length, &processed);

Included a unit test, `TEST(StringToTemplate)`.

Fixes issue https://github.com/google/double-conversion/issues/157

With help from Florian Loitsch (@floitsch)