### PR TITLE
double-conversion/utils.h: Add support of Synopsys ARC64 architecture

### DIFF
--- a/double-conversion/utils.h
+++ b/double-conversion/utils.h
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
     defined(_MIPS_ARCH_MIPS32R2) || defined(__ARMEB__) ||\
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || defined(__e2k__) || \
-    defined(__or1k__) || defined(__arc__) || \
+    defined(__or1k__) || defined(__arc__) || defined(__ARC64__) || \
     defined(__microblaze__) || defined(__XTENSA__) || \
     defined(__EMSCRIPTEN__) || defined(__wasm32__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1


### PR DESCRIPTION
This PR is to add support of Synopsys ARC64 architecture