### PR TITLE
Set permissions for github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/scons.yml
+++ b/.github/workflows/scons.yml
@@ -2,6 +2,9 @@ name: scons
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Set top level permission as `contents: read` to both ci.yml and scons.yml

Example of success runs after the changes:

- https://github.com/joycebrum/double-conversion/actions/runs/4286653962
- https://github.com/joycebrum/double-conversion/actions/runs/4286653976
