### PR TITLE
Add flags to control trailing decimal and zero in exponent form when input has one significant digit

### DIFF
--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -79,21 +79,10 @@ void DoubleToStringConverter::CreateExponentialRepresentation(
     StringBuilder* result_builder) const {
   DOUBLE_CONVERSION_ASSERT(length != 0);
   result_builder->AddCharacter(decimal_digits[0]);
-
-  /* If the mantissa of the scientific notation representation is an integer number,
-   * the EMIT_TRAILING_DECIMAL_POINT flag will add a '.' character at the end of the
-   * representation:
-   * - With EMIT_TRAILING_DECIMAL_POINT enabled -> 0.0009 => 9.E-4
-   * - With EMIT_TRAILING_DECIMAL_POINT disabled -> 0.0009 => 9E-4
-   *
-   * If the mantissa is an integer and the EMIT_TRAILING_ZERO_AFTER_POINT flag is enabled
-   * it will add a '0' character at the end of the mantissa representation. Note that that
-   * flag depends on EMIT_TRAILING_DECIMAL_POINT flag be enabled.*/
-  if(length == 1){
-    if ((flags_ & EMIT_TRAILING_DECIMAL_POINT) != 0) {
+  if(length == 1) {
+    if ((flags_ & EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL) != 0) {
       result_builder->AddCharacter('.');
-
-      if ((flags_ & EMIT_TRAILING_ZERO_AFTER_POINT) != 0) {
+      if ((flags_ & EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL) != 0) {
           result_builder->AddCharacter('0');
       }
     }

--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -79,7 +79,25 @@ void DoubleToStringConverter::CreateExponentialRepresentation(
     StringBuilder* result_builder) const {
   DOUBLE_CONVERSION_ASSERT(length != 0);
   result_builder->AddCharacter(decimal_digits[0]);
-  if (length != 1) {
+
+  /* If the mantissa of the scientific notation representation is an integer number,
+   * the EMIT_TRAILING_DECIMAL_POINT flag will add a '.' character at the end of the
+   * representation:
+   * - With EMIT_TRAILING_DECIMAL_POINT enabled -> 0.0009 => 9.E-4
+   * - With EMIT_TRAILING_DECIMAL_POINT disabled -> 0.0009 => 9E-4
+   *
+   * If the mantissa is an integer and the EMIT_TRAILING_ZERO_AFTER_POINT flag is enabled
+   * it will add a '0' character at the end of the mantissa representation. Note that that
+   * flag depends on EMIT_TRAILING_DECIMAL_POINT flag be enabled.*/
+  if(length == 1){
+    if ((flags_ & EMIT_TRAILING_DECIMAL_POINT) != 0) {
+      result_builder->AddCharacter('.');
+
+      if ((flags_ & EMIT_TRAILING_ZERO_AFTER_POINT) != 0) {
+          result_builder->AddCharacter('0');
+      }
+    }
+  } else { 
     result_builder->AddCharacter('.');
     result_builder->AddSubstring(&decimal_digits[1], length-1);
   }

--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -79,14 +79,14 @@ void DoubleToStringConverter::CreateExponentialRepresentation(
     StringBuilder* result_builder) const {
   DOUBLE_CONVERSION_ASSERT(length != 0);
   result_builder->AddCharacter(decimal_digits[0]);
-  if(length == 1) {
+  if (length == 1) {
     if ((flags_ & EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL) != 0) {
       result_builder->AddCharacter('.');
       if ((flags_ & EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL) != 0) {
           result_builder->AddCharacter('0');
       }
     }
-  } else { 
+  } else {
     result_builder->AddCharacter('.');
     result_builder->AddSubstring(&decimal_digits[1], length-1);
   }

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -154,7 +154,8 @@ class DoubleToStringConverter {
   //   ToShortest(0.0009) -> "9.e-4"
   //     with EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL activated.
   //   ToShortest(0.0009) -> "9.0e-4"
-  //     with EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL activated.
+  //     with EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL activated and
+  //     EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL activated.
   //
   // The min_exponent_width is used for exponential representations.
   // The converter adds leading '0's to the exponent until the exponent

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -102,7 +102,7 @@ class DoubleToStringConverter {
   //  - EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL: when the input number has
   //    exactly one significant digit and is converted into exponent form then a
   //    trailing decimal point is appended to the significand in shortest mode
-  //    or in other modes with one requested digit.
+  //    or in precision mode with one requested digit.
   //  - EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL: in addition to a trailing
   //    decimal point emits a trailing '0'-character. This flag requires the
   //    EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL flag.

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -102,7 +102,7 @@ class DoubleToStringConverter {
   //  - EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL: when the input number has
   //    exactly one significant digit and is converted into exponent form then a
   //    trailing decimal point is appended to the significand in shortest mode
-  //    or in precision mode with one requested digit.
+  //    or in other modes with one requested digit.
   //  - EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL: in addition to a trailing
   //    decimal point emits a trailing '0'-character. This flag requires the
   //    EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL flag.

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -78,7 +78,9 @@ class DoubleToStringConverter {
     EMIT_TRAILING_DECIMAL_POINT = 2,
     EMIT_TRAILING_ZERO_AFTER_POINT = 4,
     UNIQUE_ZERO = 8,
-    NO_TRAILING_ZERO = 16
+    NO_TRAILING_ZERO = 16,
+    EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL = 32,
+    EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL = 64
   };
 
   // Flags should be a bit-or combination of the possible Flags-enum.
@@ -97,6 +99,13 @@ class DoubleToStringConverter {
   //    of the result in precision mode. Matches printf's %g.
   //    When EMIT_TRAILING_ZERO_AFTER_POINT is also given, one trailing zero is
   //    preserved.
+  //  - EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL: when the input number has
+  //    exactly one significant digit and is converted into exponent form then a
+  //    trailing decimal point is appended to the significand in shortest mode
+  //    or in precision mode with one requested digit.
+  //  - EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL: in addition to a trailing
+  //    decimal point emits a trailing '0'-character. This flag requires the
+  //    EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL flag.
   //
   // Infinity symbol and nan_symbol provide the string representation for these
   // special values. If the string is NULL and the special value is encountered
@@ -132,16 +141,20 @@ class DoubleToStringConverter {
   //   ToPrecision(230.0, 2) -> "230."  with EMIT_TRAILING_DECIMAL_POINT.
   //   ToPrecision(230.0, 2) -> "2.3e2" with EMIT_TRAILING_ZERO_AFTER_POINT.
   //
-  // When converting numbers to scientific notation representation, if the mantissa of
-  // the representation is an integer number, the EMIT_TRAILING_DECIMAL_POINT flag will
-  // add a '.' character at the end of the representation:
-  // - With EMIT_TRAILING_DECIMAL_POINT enabled -> 0.0009 => 9.E-4
-  // - With EMIT_TRAILING_DECIMAL_POINT disabled -> 0.0009 => 9E-4
-  //
-  // If the mantissa is an integer and the EMIT_TRAILING_ZERO_AFTER_POINT flag is enabled
-  // it will add a '0' character at the end of the mantissa representation. Note that that
-  // flag depends on EMIT_TRAILING_DECIMAL_POINT flag be enabled.
-  // - With EMIT_TRAILING_ZERO_AFTER_POINT enabled -> 0.0009 => 9.0E-4
+  // When converting numbers with exactly one significant digit to exponent
+  // form in shortest mode or in precision mode with one requested digit, the
+  // EMIT_TRAILING_DECIMAL_POINT and EMIT_TRAILING_ZERO_AFTER_POINT flags have
+  // no effect. Use the EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL flag to
+  // append a decimal point in this case and the
+  // EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL flag to also append a
+  // '0'-character in this case.
+  // Example with decimal_in_shortest_low = 0:
+  //   ToShortest(0.0009) -> "9e-4"
+  //     with EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL deactivated.
+  //   ToShortest(0.0009) -> "9.e-4"
+  //     with EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL activated.
+  //   ToShortest(0.0009) -> "9.0e-4"
+  //     with EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL activated.
   //
   // The min_exponent_width is used for exponential representations.
   // The converter adds leading '0's to the exponent until the exponent

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -132,6 +132,17 @@ class DoubleToStringConverter {
   //   ToPrecision(230.0, 2) -> "230."  with EMIT_TRAILING_DECIMAL_POINT.
   //   ToPrecision(230.0, 2) -> "2.3e2" with EMIT_TRAILING_ZERO_AFTER_POINT.
   //
+  // When converting numbers to scientific notation representation, if the mantissa of
+  // the representation is an integer number, the EMIT_TRAILING_DECIMAL_POINT flag will
+  // add a '.' character at the end of the representation:
+  // - With EMIT_TRAILING_DECIMAL_POINT enabled -> 0.0009 => 9.E-4
+  // - With EMIT_TRAILING_DECIMAL_POINT disabled -> 0.0009 => 9E-4
+  //
+  // If the mantissa is an integer and the EMIT_TRAILING_ZERO_AFTER_POINT flag is enabled
+  // it will add a '0' character at the end of the mantissa representation. Note that that
+  // flag depends on EMIT_TRAILING_DECIMAL_POINT flag be enabled.
+  // - With EMIT_TRAILING_ZERO_AFTER_POINT enabled -> 0.0009 => 9.0E-4
+  //
   // The min_exponent_width is used for exponential representations.
   // The converter adds leading '0's to the exponent until the exponent
   // is at least min_exponent_width digits long.

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -278,6 +278,32 @@ TEST(DoubleToShortest) {
   builder.Reset();
   CHECK(dc6.ToShortest(-Double::NaN(), &builder));
   CHECK_EQ("NaN", builder.Finalize());
+
+  // Test examples with one significant digit.
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT;
+  DoubleToStringConverter dc7(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc8(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc9(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+
+  builder.Reset();
+  CHECK(dc7.ToShortest(0.0009, &builder));
+  CHECK_EQ("9e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc8.ToShortest(0.0009, &builder));
+  CHECK_EQ("9.e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc9.ToShortest(0.0009, &builder));
+  CHECK_EQ("9.0e-4", builder.Finalize());
 }
 
 
@@ -1259,6 +1285,32 @@ TEST(DoubleToPrecision) {
   builder.Reset();
   CHECK(dc5.ToPrecision(2000080, 5, &builder));
   CHECK_EQ("2.0001e6", builder.Finalize());
+
+  // Test examples with one significant digit.
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT;
+  DoubleToStringConverter dc12(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc13(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc14(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+
+  builder.Reset();
+  CHECK(dc12.ToPrecision(0.0009, 1, &builder));
+  CHECK_EQ("9e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc13.ToPrecision(0.0009, 1, &builder));
+  CHECK_EQ("9.e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc14.ToPrecision(0.0009, 1, &builder));
+  CHECK_EQ("9.0e-4", builder.Finalize());
 }
 
 

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -991,32 +991,6 @@ TEST(DoubleToExponential) {
   builder.Reset();
   CHECK(dc5.ToExponential(1.0, 6, &builder));
   CHECK_EQ("1.000000e00", builder.Finalize());
-
-  // Test examples with one significant digit.
-  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
-      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT;
-  DoubleToStringConverter dc6(flags, NULL, NULL, 'e', 0, 0, 0, 0);
-  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
-      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
-      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL;
-  DoubleToStringConverter dc7(flags, NULL, NULL, 'e', 0, 0, 0, 0);
-  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
-      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
-      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL |
-      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL;
-  DoubleToStringConverter dc8(flags, NULL, NULL, 'e', 0, 0, 0, 0);
-
-  builder.Reset();
-  CHECK(dc6.ToExponential(0.0009, 1, &builder));
-  CHECK_EQ("9e-4", builder.Finalize());
-
-  builder.Reset();
-  CHECK(dc7.ToExponential(0.0009, 1, &builder));
-  CHECK_EQ("9.e-4", builder.Finalize());
-
-  builder.Reset();
-  CHECK(dc8.ToExponential(0.0009, 1, &builder));
-  CHECK_EQ("9.0e-4", builder.Finalize());
 }
 
 

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -991,6 +991,32 @@ TEST(DoubleToExponential) {
   builder.Reset();
   CHECK(dc5.ToExponential(1.0, 6, &builder));
   CHECK_EQ("1.000000e00", builder.Finalize());
+
+  // Test examples with one significant digit.
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT;
+  DoubleToStringConverter dc6(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc7(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+  flags = DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT |
+      DoubleToStringConverter::EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL |
+      DoubleToStringConverter::EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL;
+  DoubleToStringConverter dc8(flags, NULL, NULL, 'e', 0, 0, 0, 0);
+
+  builder.Reset();
+  CHECK(dc6.ToExponential(0.0009, 1, &builder));
+  CHECK_EQ("9e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc7.ToExponential(0.0009, 1, &builder));
+  CHECK_EQ("9.e-4", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc8.ToExponential(0.0009, 1, &builder));
+  CHECK_EQ("9.0e-4", builder.Finalize());
 }
 
 


### PR DESCRIPTION
~~This implements an improvement in how the `EMIT_TRAILING_DECIMAL_POINT` and `EMIT_TRAILING_ZERO_AFTER_POINT` flags affect~~  This adds new flags `EMIT_TRAILING_DECIMAL_POINT_IN_EXPONENTIAL` and `EMIT_TRAILING_ZERO_AFTER_POINT_IN_EXPONENTIAL` to control the trailing decimal and zero in conversion to scientific notation when the input number has exactly one significant digit.

These flags control the behavior of `ToShortest()` and `ToPrecision(, 1)` which currently do not respect the existing flags `EMIT_TRAILING_DECIMAL_POINT` and `EMIT_TRAILING_ZERO_AFTER_POINT` in this situation. `ToExponential()` OTOH _does_ respect the existing flags in this situation, and its behavior is unaffected by these new flags.

For example: when both of the new flags are activated, `ToShortest(0.00001)` and `ToPrecision(0.00001, 1)` both currently emit `1E-5`, but after this PR they both emit `1.0E-5`.

This change was originally made in Apache Arrow's vendored copy of double-conversion in https://github.com/apache/arrow/pull/9816. The Apache Arrow developers would like to contribute this improvement upstream so that we can depend directly on upstream double-conversion. Thank you.