### PR TITLE
Hash pin Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.container }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Configure
         shell: bash

--- a/.github/workflows/scons.yml
+++ b/.github/workflows/scons.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
#197 

## Changes

Hash pin GitHub Owned Workflows: although they are more trustful than the overall github actions it is important to notice that they are still open source projects.

Let me know what you think.

PS: this is just an extra precaution, the workflow is already safe enough following minimal permissions on workflow. The hash pin will only ensure that no "malicious" version will be running instead of the original and trustful one.