### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # Necessary to update action hashs	
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 3 opened pull requests for github-actions versions
+    open-pull-requests-limit: 3


### PR DESCRIPTION
Closes #197 

### Changes
I'm submiting a configuration file for dependabot (official from GitHub) to update only github workflows and limited up to 3 PRs per week (let me know if you rather this to be greater of smaler)

I think you also has to enable `Dependabot version updates` at https://github.com/google/double-conversion/settings/security_analysis to it actually works once it got merged.
