### PR TITLE
Add _ITERATOR_DEBUG_LEVEL=2 and _DEBUG defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,11 @@ project(double-conversion VERSION 3.3.0)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)
 
-if(BUILD_SHARED_LIBS AND MSVC)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+if(MSVC)
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /D_ITERATOR_DEBUG_LEVEL=2")
 endif()
 
 set(headers

--- a/msvc/double-conversion.vcxproj
+++ b/msvc/double-conversion.vcxproj
@@ -88,7 +88,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_ITERATOR_DEBUG_LEVEL=2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
@@ -102,7 +102,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_ITERATOR_DEBUG_LEVEL=2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>


### PR DESCRIPTION
On Windows, the _ITERATOR_DEBUG_LEVEL flag is not set for Debug builds.  This causes mismatch errors when attempting to build consuming codebases where this flag *is* set.

I have personally run in to this issue when attempting to build Qt 5.15.2.

My change appends `_ITERATOR_DEBUG_LEVEL=2` and `_DEBUG` to the `CMAKE_CXX_FLAGS_DEBUG` variable, allowing the values to appear in the preprocessor list in the generated .vcxproj file (debug only).  The flags have also been manually added to the existing .vcxproj file, in the `msvc/` directory.