### PR TITLE
Add bzlmod MODULE.bazel file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "double-conversion",
+    compatibility_level = 1,
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.6")


### PR DESCRIPTION
This adds support for building this module with bazel's bzlmod dependency management enabled.