### PR TITLE
Update MODULE.bazel and README.md.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,9 @@
+"""This project (double-conversion) provides binary-decimal and decimal-binary routines for IEEE doubles."""
+
 module(
     name = "double-conversion",
-    compatibility_level = 1,
-    version = "0.0.0",
+    version = "3.3.0",
+    compatibility_level = 3,
 )
 
-bazel_dep(name = "rules_cc", version = "0.0.6")
+bazel_dep(name = "rules_cc", version = "0.0.13")

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There is extensive documentation in `double-conversion/string-to-double.h` and
 Building
 ========
 
-This library can be built with [scons][0] or [cmake][1].
+This library can be built with [scons][0], [cmake][1] or [bazel][2].
 The checked-in Makefile simply forwards to scons, and provides a
 shortcut to run all tests:
 
@@ -55,5 +55,23 @@ Use `-DBUILD_TESTING=ON` to build the test executable.
     make
     test/cctest/cctest
 
+Bazel
+---
+
+The simplest way to adopt this library is through the [Bazel Central Registry](https://registry.bazel.build/modules/double-conversion).
+
+To build the library from the latest repository, run:
+
+```
+bazel build //:double-conversion
+```
+
+To run the unit test, run:
+
+```
+bazel test //:cctest
+```
+
 [0]: http://www.scons.org/
 [1]: https://cmake.org/
+[2]: https://bazel.build/


### PR DESCRIPTION
This pull request is to upstream the change in the Bazel registry: https://github.com/bazelbuild/bazel-central-registry/blob/072b50524565ef21da258d7d9eaab057c5a8db33/modules/double-conversion/3.3.0/MODULE.bazel

As a general rule, `compatibility_level` is set to the major version number.