### PR TITLE
Remove the explicit dependency on rules_cc.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,5 @@
 # Bazel(http://bazel.io) BUILD file
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 licenses(["notice"])
 
 exports_files(["LICENSE"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,5 +5,3 @@ module(
     version = "3.3.0",
     compatibility_level = 3,
 )
-
-bazel_dep(name = "rules_cc", version = "0.0.13")


### PR DESCRIPTION
In general, `cc_library` and `cc_test` do not need an explicit load. By removing it, we can remove the explicit dependency to `rules_cc` in `MODULE.bazel`. This makes the dependency management easier. Nothing should be broken by this change.