### PR TITLE
Add missing headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 set(headers
     double-conversion/bignum.h
+    double-conversion/bignum-dtoa.h
     double-conversion/cached-powers.h
     double-conversion/diy-fp.h
     double-conversion/double-conversion.h

--- a/test/cctest/cctest.h
+++ b/test/cctest/cctest.h
@@ -28,6 +28,7 @@
 #ifndef CCTEST_H_
 #define CCTEST_H_
 
+#include <cinttypes>
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>


### PR DESCRIPTION
Two changes:

1. Add `#include <cinttypes>` to `test/cctest/cctest.h`. Without it, on Linux systems, the following error occurs:

```
note: 'PRId64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
```

and similarly for `PRIu64` macro. 


2. `double-conversion/bignum-dtoa.h` added as a required header in `CMakeLists.txt`.

`double-conversion/bignum-dtoa.cc` is added to the library which references this header.