### PR TITLE
CMake: Raised required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(double-conversion VERSION 3.3.0)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)


### PR DESCRIPTION
CMake >= 4.0.0-rc1 removed compatibility with versions < 3.5 and errors out with such versions passed to cmake_minimum_required(). 3.5.0 has been released 9 years ago, so I'd assume it's available almost everywhere.