### PR TITLE
Always initialize decimal-point variable.

### DIFF
--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -180,7 +180,7 @@ bool DoubleToStringConverter::ToShortestIeeeNumber(
     return HandleSpecialValues(value, result_builder);
   }
 
-  int decimal_point;
+  int decimal_point = 0;
   bool sign;
   const int kDecimalRepCapacity = kBase10MaximalLength + 1;
   char decimal_rep[kDecimalRepCapacity];
@@ -405,6 +405,7 @@ void DoubleToStringConverter::DoubleToAscii(double v,
   if (mode == PRECISION && requested_digits == 0) {
     vector[0] = '\0';
     *length = 0;
+    *point = 0;
     return;
   }
 


### PR DESCRIPTION
This shouldn't have any effect since the variable was only uninitialized if 0 digits were requested. Still good practice.

Fixes #243.