### PR TITLE
Add alias double-conversion::double-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
+add_library(${namespace}::double-conversion ALIAS double-conversion)
+
 # Include module with function 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
This allows consuming the library in a `add_subdirectory` use-case as-if it was installed