### PR TITLE
Revert "Add _ITERATOR_DEBUG_LEVEL=2 and _DEBUG defines (#202)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,8 @@ project(double-conversion VERSION 3.3.0)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)
 
-if(MSVC)
-  if(BUILD_SHARED_LIBS)
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-  endif()
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /D_ITERATOR_DEBUG_LEVEL=2")
+if(BUILD_SHARED_LIBS AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 set(headers

--- a/msvc/double-conversion.vcxproj
+++ b/msvc/double-conversion.vcxproj
@@ -88,7 +88,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_ITERATOR_DEBUG_LEVEL=2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
@@ -102,7 +102,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_ITERATOR_DEBUG_LEVEL=2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>


### PR DESCRIPTION
This reverts commit dfa08c464fe164e5c70e3f080e30cc977fbb0aa9.

The original change is invalid. `_ITERATOR_DEBUG_LEVEL=2` is the default value in debug builds. And now it's impossible to override it because it's *appended* to `CMAKE_CXX_FLAGS_DEBUG`.
I suspect that the original problem was that release double-conversion library was used in debug builds of Qt. This is not something that should be fixed in double-conversion.