### PR TITLE
Fix malformed double-conversion::::double-conversion alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ target_include_directories(
 # pick a version #
 set_target_properties(double-conversion PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 3)
 
+# Alias so the library can be consumed via add_subdirectory()/FetchContent
+# under the same name as the installed package (see install(EXPORT) below).
+add_library(double-conversion::double-conversion ALIAS double-conversion)
+
 # set up testing if requested
 option(BUILD_TESTING "Build test programs" OFF)
 if(BUILD_TESTING)
@@ -67,8 +71,6 @@ set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
-
-add_library(${namespace}::double-conversion ALIAS double-conversion)
 
 # Include module with function 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)

--- a/test/cctest/CMakeLists.txt
+++ b/test/cctest/CMakeLists.txt
@@ -17,7 +17,10 @@ set(CCTEST_SRC
 )
 
 add_executable(cctest ${CCTEST_SRC})
-target_link_libraries(cctest double-conversion)
+# Link through the namespaced alias (rather than the raw "double-conversion"
+# target) so the build exercises the alias the same way an external consumer
+# does. A malformed alias makes this fail to configure. See issue #283.
+target_link_libraries(cctest double-conversion::double-conversion)
 if(MSVC)
     target_compile_options(cctest PRIVATE /bigobj)
 endif()


### PR DESCRIPTION
The namespace variable already ends with "::", so the alias definition added an extra pair of colons, producing the malformed in-tree target double-conversion::::double-conversion instead of the intended double-conversion::double-conversion.

This only affected add_subdirectory()/FetchContent consumers; the installed package built its target name from install(EXPORT NAMESPACE) and was correct, which is why nobody hit it via find_package().

Move the alias next to the library target (before add_subdirectory(test)) and have cctest link through the namespaced alias, so the build exercises it the same way an external consumer does and fails to configure on a malformed alias.

Fixes #283.