### PR TITLE
Prevent signed integer overflow while accumulating hexadecimal exponent

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -341,7 +341,13 @@ static double RadixStringToIeee(Iterator* current,
         }
         if (!isDigit(**current, radix)) break;
         zero_tail = zero_tail && **current == '0';
-        if (!post_decimal) exponent += radix_log_2;
+        if (!post_decimal) {
+          if (exponent <= INT_MAX - radix_log_2) {
+            exponent += radix_log_2;
+          } else {
+            exponent = INT_MAX;
+          }
+        }
       }
 
       if (!parse_as_hex_float &&


### PR DESCRIPTION
## Summary
Prevent signed integer overflow when parsing extremely long hexadecimal floating-point literals.

## Why
The internal exponent accumulator can exceed the range of `int` while processing extremely long hexadecimal inputs, resulting in undefined behavior. This change eliminates that possibility while preserving the existing behavior for valid inputs.
