### PR TITLE
reject negative requested_digits in ToFixed

### DIFF
--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -219,6 +219,7 @@ bool DoubleToStringConverter::ToFixed(double value,
     return HandleSpecialValues(value, result_builder);
   }
 
+  if (requested_digits < 0) return false;
   if (requested_digits > kMaxFixedDigitsAfterPoint) return false;
   if (value >= kFirstNonFixed || value <= -kFirstNonFixed) return false;
 

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -288,6 +288,7 @@ class DoubleToStringConverter {
   // except for the following cases:
   //   - the input value is special and no infinity_symbol or nan_symbol has
   //     been provided to the constructor,
+  //   - 'requested_digits' < 0,
   //   - 'value' > 10^kMaxFixedDigitsBeforePoint, or
   //   - 'requested_digits' > kMaxFixedDigitsAfterPoint.
   // The last two conditions imply that the result for non-special values never

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -592,6 +592,16 @@ TEST(DoubleToFixed) {
       9e59, DoubleToStringConverter::kMaxFixedDigitsAfterPoint + 1, &builder));
   CHECK_EQ(0, builder.position());
 
+  // A negative digit count would otherwise pad the result with
+  // -requested_digits characters, overrunning the caller's buffer.
+  builder.Reset();
+  CHECK(!dc.ToFixed(1e-30, -1, &builder));
+  CHECK_EQ(0, builder.position());
+
+  builder.Reset();
+  CHECK(!dc.ToFixed(1e-30, -1000, &builder));
+  CHECK_EQ(0, builder.position());
+
   builder.Reset();
   CHECK(dc.ToFixed(3.0, 0, &builder));
   CHECK_EQ("3", builder.Finalize());


### PR DESCRIPTION
Repro: `ToFixed(1e-30, -1000, &builder)` on a buffer sized by the header's own formula (`1 + kMaxFixedDigitsBeforePoint + 1 + kMaxFixedDigitsAfterPoint + 1`, so 163 bytes) returns true and writes 1000 characters; ASan reports a heap-buffer-overflow write in `CreateDecimalRepresentation`, and the length written is exactly `-requested_digits`.

Cause: `requested_digits` is bounded only from above, so a negative count reaches `CreateDecimalRepresentation` as `decimal_point == -requested_digits` and `AddPadding` emits that many characters. The lower bound existed only as the `DOUBLE_CONVERSION_ASSERT` in `DoubleToAscii`, which is compiled out under NDEBUG. `ToFixed(1e-30, INT_MIN)` additionally trips UBSan on the negation in `fixed-dtoa.cc:389`.

Fix: reject negative `requested_digits` up front, matching the guards `ToExponential` and `ToPrecision` already carry. Values 0 to `kMaxFixedDigitsAfterPoint` are unaffected.