### PR TITLE
correct documented result bounds for ToPrecision and ToExponential

### DIFF
--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -234,8 +234,9 @@ class DoubleToStringConverter {
   //   and the significant digits).
   //      "-0.0000033333333333333333", "-0.0012345678901234567"
   // - the longest exponential representation. (A negative number with
-  //   kBase10MaximalLength significant digits).
-  //      "-1.7976931348623157e+308", "-1.7976931348623157E308"
+  //   kBase10MaximalLength significant digits, and an exponent padded to
+  //   min_exponent_width digits).
+  //      "-1.7976931348623157e+308", "-1.7976931348623157e+00308"
   // In addition, the buffer must be able to hold the trailing '\0' character.
   //
   // Since the algorithm finds the shortest number of significant digits, it
@@ -326,9 +327,10 @@ class DoubleToStringConverter {
   //   - 'requested_digits' > kMaxExponentialDigits.
   //
   // The last condition implies that the result never contains more than
-  // kMaxExponentialDigits + 8 characters (the sign, the digit before the
+  // kMaxExponentialDigits + 10 characters (the sign, the digit before the
   // decimal point, the decimal point, the exponent character, the
-  // exponent's sign, and at most 3 exponent digits).
+  // exponent's sign, and at most 5 exponent digits; an exponent needs at most
+  // 3 digits, but min_exponent_width may pad it to 5).
   // In addition, the buffer must be able to hold the trailing '\0' character.
   bool ToExponential(double value,
                      int requested_digits,
@@ -368,8 +370,14 @@ class DoubleToStringConverter {
   //   - precision > kMaxPrecisionDigits
   //
   // The last condition implies that the result never contains more than
-  // kMaxPrecisionDigits + 7 characters (the sign, the decimal point, the
-  // exponent character, the exponent's sign, and at most 3 exponent digits).
+  // kMaxPrecisionDigits + 9 characters when it is returned in exponential
+  // format (the sign, the digit before the decimal point, the decimal point,
+  // the exponent character, the exponent's sign, and at most 5 exponent
+  // digits; an exponent needs at most 3 digits, but min_exponent_width may
+  // pad it to 5), and never more than
+  // kMaxPrecisionDigits + max_leading_padding_zeroes_in_precision_mode + 2
+  // characters when it is returned in decimal format (the sign, the decimal
+  // point, and the leading zeroes, which include the '0' before the point).
   // In addition, the buffer must be able to hold the trailing '\0' character.
   bool ToPrecision(double value,
                    int precision,

--- a/double-conversion/double-to-string.h
+++ b/double-conversion/double-to-string.h
@@ -327,10 +327,12 @@ class DoubleToStringConverter {
   //   - 'requested_digits' > kMaxExponentialDigits.
   //
   // The last condition implies that the result never contains more than
-  // kMaxExponentialDigits + 10 characters (the sign, the digit before the
+  // kMaxExponentialDigits + 8 characters (the sign, the digit before the
   // decimal point, the decimal point, the exponent character, the
-  // exponent's sign, and at most 5 exponent digits; an exponent needs at most
-  // 3 digits, but min_exponent_width may pad it to 5).
+  // exponent's sign, and at most 3 exponent digits).
+  // If min_exponent_width is greater than 3, the result also needs space
+  // for those additional padding digits. Given that min_exponent_width
+  // is clamped to 5, the result might thus have at most 2 additional characters.
   // In addition, the buffer must be able to hold the trailing '\0' character.
   bool ToExponential(double value,
                      int requested_digits,
@@ -370,11 +372,14 @@ class DoubleToStringConverter {
   //   - precision > kMaxPrecisionDigits
   //
   // The last condition implies that the result never contains more than
-  // kMaxPrecisionDigits + 9 characters when it is returned in exponential
+  // kMaxPrecisionDigits + 7 characters when it is returned in exponential
   // format (the sign, the digit before the decimal point, the decimal point,
-  // the exponent character, the exponent's sign, and at most 5 exponent
-  // digits; an exponent needs at most 3 digits, but min_exponent_width may
-  // pad it to 5), and never more than
+  // the exponent character, the exponent's sign, and at most 3 exponent
+  // digits).
+  // If min_exponent_width is greater than 3, the result also needs space
+  // for those additional padding digits. Given that min_exponent_width
+  // is clamped to 5, the result might thus have at most 2 additional characters.
+  // The result has never more than
   // kMaxPrecisionDigits + max_leading_padding_zeroes_in_precision_mode + 2
   // characters when it is returned in decimal format (the sign, the decimal
   // point, and the leading zeroes, which include the '0' before the point).

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -1324,6 +1324,55 @@ TEST(DoubleToPrecision) {
 }
 
 
+TEST(DoubleToStringMaximumResultLength) {
+  const int kBufferSize = 512;
+  char buffer[kBufferSize];
+  StringBuilder builder(buffer, kBufferSize);
+
+  // A decimal result is bounded by max_leading_padding_zeroes_in_precision_mode
+  // and not by the exponential bound: the sign, the decimal point and the
+  // leading zeroes (which include the '0' before the point) come on top of
+  // 'precision'.
+  const int kMaxLeadingPadding = 6;  // The value used by the EcmaScript
+                                     // converter.
+  const DoubleToStringConverter& dc =
+      DoubleToStringConverter::EcmaScriptConverter();
+
+  builder.Reset();
+  CHECK(dc.ToPrecision(-0.000001, 2, &builder));
+  CHECK_EQ(2 + kMaxLeadingPadding + 2, builder.position());
+  CHECK_EQ("-0.0000010", builder.Finalize());
+
+  builder.Reset();
+  CHECK(dc.ToPrecision(
+      -1.2345e-6, DoubleToStringConverter::kMaxPrecisionDigits, &builder));
+  CHECK_EQ(
+      DoubleToStringConverter::kMaxPrecisionDigits + kMaxLeadingPadding + 2,
+      builder.position());
+  builder.Finalize();
+
+  // An exponential result carries up to 5 exponent digits, since
+  // min_exponent_width pads the exponent.
+  int flags = DoubleToStringConverter::UNIQUE_ZERO |
+      DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
+  DoubleToStringConverter dc2(flags, "Infinity", "NaN", 'e', -6, 21, 6, 0, 5);
+
+  builder.Reset();
+  CHECK(dc2.ToExponential(
+      -1e-300, DoubleToStringConverter::kMaxExponentialDigits, &builder));
+  CHECK_EQ(DoubleToStringConverter::kMaxExponentialDigits + 10,
+           builder.position());
+  builder.Finalize();
+
+  builder.Reset();
+  CHECK(dc2.ToPrecision(
+      -1e-300, DoubleToStringConverter::kMaxPrecisionDigits, &builder));
+  CHECK_EQ(DoubleToStringConverter::kMaxPrecisionDigits + 9,
+           builder.position());
+  builder.Finalize();
+}
+
+
 TEST(DoubleToStringJavaScript) {
   const int kBufferSize = 128;
   char buffer[kBufferSize];


### PR DESCRIPTION
Repro: with the stock `EcmaScriptConverter`, `ToPrecision(-0.000001, 2, &builder)` emits the 10-character `-0.0000010` into a builder sized by the header's own rule (`precision + 7`, plus one for the `\0`), and ASan reports a heap-buffer-overflow write on the terminating NUL; `ToPrecision(-1.2345e-6, 120)` does the same at 128 characters against a documented 127.

Cause: the `kMaxPrecisionDigits + 7` accounting covers only the exponential form, while a decimal result puts the sign, the decimal point and up to `max_leading_padding_zeroes_in_precision_mode` leading zeroes on top of `precision`. `ToExponential` and `ToPrecision` also both claim at most 3 exponent digits, where `min_exponent_width` is clamped to 5 and pads the exponent to that width.

Fix: state the bounds the conversions actually observe. The emitted digits are right in every one of these cases, so the sizes were the only thing wrong and no conversion changes; the test pins the observed maxima so the numbers cannot drift again.