### PR TITLE
Bump actions/upload-artifact to 7.0.1

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,7 @@ jobs:
        fuzz-seconds: 300
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
+     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,7 +50,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
See https://github.com/actions/upload-artifact/releases/tag/v7.0.1

For `cifuzz.yml` the previous pinned version (https://github.com/actions/upload-artifact/commit/65d862660abb392b8c4a3d1195a2108db131dd05) was apparently not a release but just some commit around v3 (?), which is also not supported anymore. So if fuzzing had actually found something, it is quite likely that uploading the result would have failed.

And for `scorecard.yml` the workflow already logged a warning about Node.js 20 being deprecated.

Not sure why Dependabot had not attempted to update either of them so far. Maybe updates for that dependency had been ignored in the past (could try running `@dependabot show actions/upload-artifact ignore conditions`), or maybe the issue is the open PR limit:
https://github.com/google/double-conversion/blob/9ae489fdb5107e1473198d46691e93b75ddfe497/.github/dependabot.yml#L8