### PR TITLE
reject digit separator inside hex-float exponents

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -251,14 +251,17 @@ static bool IsHexFloatString(Iterator start,
   }
   if (!saw_digit) return false;
   if (*current != 'p' && *current != 'P') return false;
-  if (Advance(&current, separator, 16, end)) return false;
+  // The separator is only allowed between significand digits, not in the
+  // exponent, so advance through the exponent with no separator.
+  const uc16 kNoSeparator = StringToDoubleConverter::kNoSeparator;
+  if (Advance(&current, kNoSeparator, 16, end)) return false;
   if (*current == '+' || *current == '-') {
-    if (Advance(&current, separator, 16, end)) return false;
+    if (Advance(&current, kNoSeparator, 16, end)) return false;
   }
   if (!isDigit(*current, 10)) return false;
-  if (Advance(&current, separator, 16, end)) return true;
+  if (Advance(&current, kNoSeparator, 16, end)) return true;
   while (isDigit(*current, 10)) {
-    if (Advance(&current, separator, 16, end)) return true;
+    if (Advance(&current, kNoSeparator, 16, end)) return true;
   }
   return allow_trailing_junk || !AdvanceToNonspace(&current, end);
 }
@@ -400,15 +403,19 @@ static double RadixStringToIeee(Iterator* current,
 
   if (parse_as_hex_float) {
     DOUBLE_CONVERSION_ASSERT(**current == 'p' || **current == 'P');
-    Advance(current, separator, radix, end);
+    // The separator is only allowed between significand digits, not in the
+    // exponent, so advance through the exponent with no separator. This must
+    // match IsHexFloatString, which validated the string the same way.
+    const uc16 kNoSeparator = StringToDoubleConverter::kNoSeparator;
+    Advance(current, kNoSeparator, radix, end);
     DOUBLE_CONVERSION_ASSERT(*current != end);
     bool is_negative = false;
     if (**current == '+') {
-      Advance(current, separator, radix, end);
+      Advance(current, kNoSeparator, radix, end);
       DOUBLE_CONVERSION_ASSERT(*current != end);
     } else if (**current == '-') {
       is_negative = true;
-      Advance(current, separator, radix, end);
+      Advance(current, kNoSeparator, radix, end);
       DOUBLE_CONVERSION_ASSERT(*current != end);
     }
     int written_exponent = 0;
@@ -418,7 +425,7 @@ static double RadixStringToIeee(Iterator* current,
       if (abs(written_exponent) <= 100 * Double::kMaxExponent) {
         written_exponent = 10 * written_exponent + **current - '0';
       }
-      if (Advance(current, separator, radix, end)) break;
+      if (Advance(current, kNoSeparator, radix, end)) break;
     }
     if (is_negative) written_exponent = -written_exponent;
     exponent += written_exponent;

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -4091,6 +4091,37 @@ TEST(StringToDoubleSeparator) {
            StrToD16("0x0@3.p0", flags, 0.0, &processed, &all_used,
                     char_separator, separator));
   CHECK(all_used);
+
+  // The separator is only allowed between significand digits, not in the
+  // exponent. The decimal exponent already rejects it; the hex-float exponent
+  // must reject it too.
+  separator = '_';
+  flags = StringToDoubleConverter::ALLOW_HEX |
+      StringToDoubleConverter::ALLOW_HEX_FLOATS;
+
+  CHECK_EQ(144.0,  // 0x12p3, separator between significand digits.
+           StrToD("0x1_2p3", flags, 0.0, &processed, &all_used, separator));
+  CHECK(all_used);
+
+  CHECK_EQ(1024.0,  // 0x1p10, no separator in the exponent.
+           StrToD("0x1p10", flags, 0.0, &processed, &all_used, separator));
+  CHECK(all_used);
+
+  CHECK_EQ(Double::NaN(),
+           StrToD("0x1p1_0", flags, 0.0, &processed, &all_used, separator));
+  CHECK_EQ(0, processed);
+
+  CHECK_EQ(Double::NaN(),
+           StrToD("0x1.8p1_0", flags, 0.0, &processed, &all_used, separator));
+  CHECK_EQ(0, processed);
+
+  CHECK_EQ(Double::NaN(),
+           StrToD("0x1p_10", flags, 0.0, &processed, &all_used, separator));
+  CHECK_EQ(0, processed);
+
+  CHECK_EQ(Double::NaN(),
+           StrToD("0x1p10_", flags, 0.0, &processed, &all_used, separator));
+  CHECK_EQ(0, processed);
 }
 
 TEST(StringToDoubleSpecialValues) {


### PR DESCRIPTION
Repro: with a digit separator set and ALLOW_HEX_FLOATS, "0x1p1_0" parses to 1024 and "0x1.8p1_0" to 1536; both should be junk.
Cause: IsHexFloatString and RadixStringToIeee advance through the hex-float exponent with the active separator, so a separator between two exponent digits is consumed. The decimal exponent uses a plain increment and already rejects "1e1_0".
Fix: advance through the hex-float exponent with kNoSeparator in both the validator and the parser, matching the documented rule that the separator is only allowed between significand digits. Significand separators and valid hex-floats are unchanged; a regression test sits beside the existing separator cases.