### PR TITLE
fix hex-floats becoming infinity or zero in RadixStringToIeee

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -433,7 +433,12 @@ static double RadixStringToIeee(Iterator* current,
   }
 
   DOUBLE_CONVERSION_ASSERT(number != 0);
-  double result = Double(DiyFp(number, exponent)).value();
+  // number is an exact integer below 2^kSignificandSize, so number * 2^exponent
+  // can be formed directly. Double(DiyFp(number, exponent)) would instead assume
+  // a normalized significand: a hex-float like "0x1p1000" or "0x2p-1075" reaches
+  // here with a small number and a large exponent, which DiyFpToUint64 then reads
+  // as an overflow (infinity) or underflow (zero) rather than the finite result.
+  double result = ldexp(static_cast<double>(number), exponent);
   return sign ? -result : result;
 }
 

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -3099,6 +3099,39 @@ TEST(StringToDoubleHexString) {
   CHECK_EQ(-0.0, StrToD("-0x1p-2000", flags, 0.0, &processed, &all_used));
   CHECK(all_used);
 
+  // Large-but-finite hex-floats must not overflow to infinity. Every value
+  // below is a normal double well within range (2^1023 is the largest power of
+  // two that fits).
+  CHECK_EQ(1.0715086071862673e+301, StrToD("0x1p1000", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  CHECK_EQ(8.9884656743115795e+307, StrToD("0x1p1023", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  CHECK_EQ(1.6853373139334212e+307, StrToD("0x1.8p1020", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  CHECK_EQ(5.8251712944653672e+299, StrToD("0xdeadp980", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  // Small subnormals must not underflow to zero. 2^-1074 is the smallest
+  // positive double, reachable as "0x2p-1075" or "0x1p-1074".
+  CHECK_EQ(4.9406564584124654e-324, StrToD("0x2p-1075", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  CHECK_EQ(4.9406564584124654e-324, StrToD("0x1p-1074", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
+  CHECK_EQ(1.4821969375237396e-323, StrToD("0x3p-1074", flags, 0.0,
+                                           &processed, &all_used));
+  CHECK(all_used);
+
   CHECK_EQ(Double::NaN(), StrToD(" ", flags, Double::NaN(),
                                  &processed, &all_used));
   CHECK_EQ(0, processed);


### PR DESCRIPTION
Repro: with ALLOW_HEX_FLOATS, "0x1p1000" returns +infinity and "0x2p-1075" returns 0, although both are finite doubles (2^1000, and the smallest subnormal). strtod parses them correctly.
Cause: RadixStringToIeee forms the result with Double(DiyFp(number, exponent)), passing the raw accumulated significand. DiyFpToUint64 assumes a normalised significand, so its range checks read any hex-float at or above 2^972 as an overflow and small subnormals as an underflow.
Fix: scale the exact integer significand with ldexp, which rounds correctly across the normal, subnormal and overflow ranges.