### PR TITLE
fold the special-value symbol too under case insensitivity

### DIFF
--- a/double-conversion/string-to-double.cc
+++ b/double-conversion/string-to-double.cc
@@ -78,11 +78,12 @@ static inline bool ConsumeSubStringImpl(Iterator* current,
                                         Iterator end,
                                         const char* substring,
                                         Converter converter) {
-  DOUBLE_CONVERSION_ASSERT(converter(CodeUnit(**current)) == CodeUnit(*substring));
+  DOUBLE_CONVERSION_ASSERT(
+      converter(CodeUnit(**current)) == converter(CodeUnit(*substring)));
   for (substring++; *substring != '\0'; substring++) {
     ++*current;
     if (*current == end ||
-        converter(CodeUnit(**current)) != CodeUnit(*substring)) {
+        converter(CodeUnit(**current)) != converter(CodeUnit(*substring))) {
       return false;
     }
   }
@@ -111,7 +112,7 @@ inline bool ConsumeFirstCharacter(Char ch,
                                          bool case_insensitivity) {
   const uint32_t c = CodeUnit(ch);
   const uint32_t first = CodeUnit(str[0]);
-  return case_insensitivity ? ToLower(c) == first : c == first;
+  return case_insensitivity ? ToLower(c) == ToLower(first) : c == first;
 }
 }  // namespace
 

--- a/test/cctest/test-conversions.cc
+++ b/test/cctest/test-conversions.cc
@@ -6066,6 +6066,51 @@ TEST(StringToDoubleCaseInsensitiveSpecialValues) {
 }
 
 
+TEST(StringToDoubleCaseInsensitiveMixedCaseSymbols) {
+  int processed = 0;
+
+  const int flags = StringToDoubleConverter::ALLOW_CASE_INSENSITIVITY;
+
+  // The symbols carry upper-case letters. Case-insensitive matching must fold
+  // both the input and the symbol, so any casing of the input is accepted,
+  // including the symbol's own spelling.
+  StringToDoubleConverter converter(flags, 0.0, 1.0, "Infinity", "NaN");
+
+  CHECK_EQ(Double::Infinity(),
+           converter.StringToDouble("Infinity", 8, &processed));
+  CHECK_EQ(8, processed);
+
+  CHECK_EQ(Double::Infinity(),
+           converter.StringToDouble("infinity", 8, &processed));
+  CHECK_EQ(8, processed);
+
+  CHECK_EQ(Double::Infinity(),
+           converter.StringToDouble("INFINITY", 8, &processed));
+  CHECK_EQ(8, processed);
+
+  CHECK_EQ(Double::NaN(), converter.StringToDouble("nan", 3, &processed));
+  CHECK_EQ(3, processed);
+
+  CHECK_EQ(Double::NaN(), converter.StringToDouble("NAN", 3, &processed));
+  CHECK_EQ(3, processed);
+
+  const uc16 infinity16[] = { 'i', 'N', 'f', 'I', 'n', 'I', 't', 'Y' };
+  CHECK_EQ(Double::Infinity(),
+           converter.StringToDouble(infinity16, 8, &processed));
+  CHECK_EQ(8, processed);
+
+  // A case-sensitive converter with the same symbols still rejects a spelling
+  // that differs only in case.
+  StringToDoubleConverter cs(StringToDoubleConverter::NO_FLAGS,
+                             0.0, 1.0, "Infinity", "NaN");
+  CHECK_EQ(1.0, cs.StringToDouble("infinity", 8, &processed));
+  CHECK_EQ(0, processed);
+  CHECK_EQ(Double::Infinity(),
+           cs.StringToDouble("Infinity", 8, &processed));
+  CHECK_EQ(8, processed);
+}
+
+
 TEST(StringToDoubleNonAsciiSpecialValues) {
   int processed = 0;
 


### PR DESCRIPTION
Repro: build a converter with `ALLOW_CASE_INSENSITIVITY` and the EcmaScript symbols `infinity_symbol_ = "Infinity"`, `nan_symbol_ = "NaN"`. `StringToDouble("Infinity")`, `StringToDouble("infinity")` and `StringToDouble("INFINITY")` all return `junk_string_value` with `processed_characters_count == 0`; the same holds for every casing of `NaN`. Lower-case symbols (`"infinity"`/`"nan"`) are matched fine, which is why the existing case-insensitive test never caught it.

Cause: the fold is applied to the input character only. `ConsumeFirstCharacter` compares `ToLower(input) == symbol_first` and `ConsumeSubStringImpl` compares `converter(input) != symbol_byte`, both leaving the symbol side un-folded. Any symbol byte that is an upper-case letter therefore never equals the lower-cased input, so no input matches, not even the symbol's own spelling.

Fix: fold both sides. `ToLower(first)` in `ConsumeFirstCharacter`, and `converter(CodeUnit(*substring))` in `ConsumeSubStringImpl` and its assert. The case-sensitive path passes `Pass` (identity), so it keeps rejecting a spelling that differs only in case. Regression test added beside the existing case-insensitive cases, using upper-case symbols across both the `char` and `uc16` overloads.