### PR TITLE
guard zero digit count in GenerateCountedDigits

### DIFF
--- a/double-conversion/bignum-dtoa.cc
+++ b/double-conversion/bignum-dtoa.cc
@@ -284,6 +284,11 @@ static void GenerateCountedDigits(int count, int* decimal_point,
                                   Bignum* numerator, Bignum* denominator,
                                   Vector<char> buffer, int* length) {
   DOUBLE_CONVERSION_ASSERT(count >= 0);
+  if (count == 0) {
+    // No digits requested. The "last digit" store below would write buffer[-1].
+    *length = 0;
+    return;
+  }
   for (int i = 0; i < count - 1; ++i) {
     uint16_t digit;
     digit = numerator->DivideModuloIntBignum(*denominator);

--- a/test/cctest/test-bignum-dtoa.cc
+++ b/test/cctest/test-bignum-dtoa.cc
@@ -258,6 +258,26 @@ TEST(BignumDtoaVariousDoubles) {
 }
 
 
+TEST(BignumDtoaZeroPrecision) {
+  // Requesting zero precision digits must produce an empty representation
+  // without storing the "last digit" at buffer[-1]. A sentinel byte sits
+  // immediately before the output buffer to catch that store.
+  char container[kBufferSize];
+  container[0] = '@';
+  Vector<char> buffer(container + 1, kBufferSize - 1);
+  int length;
+  int point;
+
+  BignumDtoa(1.0, BIGNUM_DTOA_PRECISION, 0, buffer, &length, &point);
+  CHECK_EQ(0, length);
+  CHECK(container[0] == '@');
+
+  BignumDtoa(123.456, BIGNUM_DTOA_PRECISION, 0, buffer, &length, &point);
+  CHECK_EQ(0, length);
+  CHECK(container[0] == '@');
+}
+
+
 TEST(BignumDtoaShortestVariousFloats) {
   char buffer_container[kBufferSize];
   Vector<char> buffer(buffer_container, kBufferSize);


### PR DESCRIPTION
AddressSanitizer, `-DNDEBUG` build:

    ==ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 1
        #0 GenerateCountedDigits bignum-dtoa.cc:304
        #1 BignumDtoa bignum-dtoa.cc:161
    located 1 bytes before 8-byte region [...]

Reached from the public API `BignumDtoa(v, BIGNUM_DTOA_PRECISION, 0, buffer, &length, &point)`. `GenerateCountedDigits` only asserts `count >= 0` and then stores the final digit at `buffer[count - 1]`, so `count == 0` writes `buffer[-1]`. `DoubleToStringConverter::DoubleToAscii` already special-cases precision mode with zero digits one layer up; `BignumDtoa` did not. Return an empty representation when `count == 0`, before the store.