### PR TITLE
clamp strtod exponent before combining with the digit count

### DIFF
--- a/double-conversion/strtod.cc
+++ b/double-conversion/strtod.cc
@@ -119,6 +119,20 @@ static void CutToMaxSignificantDigits(Vector<const char> buffer,
 }
 
 
+// The public Strtod entry points accept an arbitrary int exponent, which is
+// later combined with the digit count (exponent + buffer.length()). For
+// exponents near INT_MAX that addition signed-overflows. Any exponent past
+// this range is far outside the representable double range, so clamping it
+// leaves the result unchanged. string-to-double.cc caps its parsed exponent
+// the same way and for the same reason.
+static int ClampExponent(int exponent) {
+  const int kMaxExponent = INT_MAX / 2;
+  if (exponent > kMaxExponent) return kMaxExponent;
+  if (exponent < -kMaxExponent) return -kMaxExponent;
+  return exponent;
+}
+
+
 // Trims the buffer and cuts it to at most kMaxSignificantDecimalDigits.
 // If possible the input-buffer is reused, but if the buffer needs to be
 // modified (due to cutting), then the input needs to be copied into the
@@ -126,6 +140,7 @@ static void CutToMaxSignificantDigits(Vector<const char> buffer,
 static void TrimAndCut(Vector<const char> buffer, int exponent,
                        char* buffer_copy_space, int space_size,
                        Vector<const char>* trimmed, int* updated_exponent) {
+  exponent = ClampExponent(exponent);
   Vector<const char> left_trimmed = TrimLeadingZeros(buffer);
   Vector<const char> right_trimmed = TrimTrailingZeros(left_trimmed);
   exponent += left_trimmed.length() - right_trimmed.length();
@@ -422,6 +437,7 @@ static bool ComputeGuess(Vector<const char> trimmed, int exponent,
     *guess = 0.0;
     return true;
   }
+  exponent = ClampExponent(exponent);
   if (exponent + trimmed.length() - 1 >= kMaxDecimalPower) {
     *guess = Double::Infinity();
     return true;

--- a/test/cctest/test-strtod.cc
+++ b/test/cctest/test-strtod.cc
@@ -26,6 +26,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>
+#include <climits>
 
 #include "double-conversion/bignum.h"
 #include "cctest.h"
@@ -243,6 +244,13 @@ TEST(Strtod) {
   CHECK_EQ(1.7976931348623157E+308, StrtodChar("17976931348623157", 292));
   CHECK_EQ(1.7976931348623158E+308, StrtodChar("17976931348623158", 292));
   CHECK_EQ(Double::Infinity(), StrtodChar("17976931348623159", 292));
+
+  // Extreme exponents must not overflow the internal exponent arithmetic
+  // (exponent + digit count). They stay out of the double range.
+  CHECK_EQ(Double::Infinity(), StrtodChar("1", INT_MAX));
+  CHECK_EQ(Double::Infinity(), StrtodChar("10", INT_MAX));
+  CHECK_EQ(0.0, StrtodChar("1", INT_MIN));
+  CHECK_EQ(0.0, StrtodChar("10", INT_MIN));
 
   // The following number is the result of 89255.0/1e-22. Both floating-point
   // numbers can be accurately represented with doubles. However on Linux,x86
@@ -531,6 +539,10 @@ TEST(StrtodTrimmed) {
   CHECK_EQ(1.7976931348623157E+308, StrtodTrimmedChar("17976931348623157", 292));
   CHECK_EQ(1.7976931348623158E+308, StrtodTrimmedChar("17976931348623158", 292));
   CHECK_EQ(Double::Infinity(), StrtodTrimmedChar("17976931348623159", 292));
+
+  // Extreme exponents must not overflow the internal exponent arithmetic.
+  CHECK_EQ(Double::Infinity(), StrtodTrimmedChar("1", INT_MAX));
+  CHECK_EQ(0.0, StrtodTrimmedChar("1", INT_MIN));
 
   // The following number is the result of 89255.0/1e-22. Both floating-point
   // numbers can be accurately represented with doubles. However on Linux,x86
@@ -824,6 +836,12 @@ TEST(Strtof) {
   CHECK_EQ(3.4028234e+38f, StrtofChar("34028235677", 28));
   CHECK_EQ(Single::Infinity(), StrtofChar("34028235678", 28));
 
+  // Extreme exponents must not overflow the internal exponent arithmetic.
+  CHECK_EQ(Single::Infinity(), StrtofChar("1", INT_MAX));
+  CHECK_EQ(Single::Infinity(), StrtofChar("10", INT_MAX));
+  CHECK_EQ(0.0f, StrtofChar("1", INT_MIN));
+  CHECK_EQ(0.0f, StrtofChar("10", INT_MIN));
+
   // The following number is the result of 89255.0/1e-22. Both floating-point
   // numbers can be accurately represented with doubles. However on Linux,x86
   // the floating-point stack is set to 80bits and the double-rounding
@@ -1014,6 +1032,10 @@ TEST(StrtofTrimmed) {
   CHECK_EQ(3.4028234e+38f, StrtofTrimmedChar("34028235676", 28));
   CHECK_EQ(3.4028234e+38f, StrtofTrimmedChar("34028235677", 28));
   CHECK_EQ(Single::Infinity(), StrtofTrimmedChar("34028235678", 28));
+
+  // Extreme exponents must not overflow the internal exponent arithmetic.
+  CHECK_EQ(Single::Infinity(), StrtofTrimmedChar("1", INT_MAX));
+  CHECK_EQ(0.0f, StrtofTrimmedChar("1", INT_MIN));
 
   // The following number is the result of 89255.0/1e-22. Both floating-point
   // numbers can be accurately represented with doubles. However on Linux,x86


### PR DESCRIPTION
Repro: `StrtodTrimmed("1", INT_MAX)` trips UBSan `signed integer overflow: 2147483647 + 1` at strtod.cc:425. `Strtod("10", INT_MAX)` overflows at strtod.cc:131 and, in a non-sanitiser build, returns 0 where the value is infinity.
Cause: the public strtod entry points accept an arbitrary `int` exponent, which `ComputeGuess` and `TrimAndCut` then add to the digit count (`exponent + trimmed.length()`) without bounding it first. `string-to-double.cc` already caps its parsed exponent at `INT_MAX/2` for this reason, but a direct caller of the strtod entry points has no such clamp.
Fix: clamp the exponent to `+/-INT_MAX/2` at both sites through a small helper. Any exponent past that range is far outside the representable double range, so the clamp leaves every valid result unchanged. Regression cases for `INT_MAX`/`INT_MIN` exponents are added across the `Strtod`, `StrtodTrimmed`, `Strtof` and `StrtofTrimmed` tests.