### PR TITLE
fix out-of-bounds write in DoubleToAscii SHORTEST_SINGLE mode

### DIFF
--- a/double-conversion/double-to-string.cc
+++ b/double-conversion/double-to-string.cc
@@ -410,7 +410,12 @@ void DoubleToStringConverter::DoubleToAscii(double v,
     return;
   }
 
-  if (v == 0) {
+  // In SHORTEST_SINGLE mode the value is rendered as a single. A positive
+  // double below the smallest positive float rounds to +0.0f, which is a
+  // single zero even though the double is non-zero. Grisu3 would then take the
+  // boundaries from Single(0.0f), whose NormalizedBoundaries precondition
+  // (value > 0) is violated, and emit far more digits than the buffer holds.
+  if (v == 0 || (mode == SHORTEST_SINGLE && static_cast<float>(v) == 0.0f)) {
     vector[0] = '0';
     vector[1] = '\0';
     *length = 1;

--- a/test/cctest/test-dtoa.cc
+++ b/test/cctest/test-dtoa.cc
@@ -93,6 +93,14 @@ TEST(DtoaVariousDoubles) {
   CHECK_EQ("0", buffer.start());
   CHECK_EQ(1, point);
 
+  // A positive double below the smallest positive float rounds to +0.0f, so in
+  // single mode it is a zero. It must render as "0" and not spill past the
+  // buffer while generating digits at the double's magnitude.
+  DoubleToAscii(5e-324, SHORTEST_SINGLE, 0, buffer, &sign, &length, &point);
+  CHECK_EQ(1, length);
+  CHECK_EQ("0", buffer.start());
+  CHECK_EQ(1, point);
+
   DoubleToAscii(0.0, FIXED, 2, buffer, &sign, &length, &point);
   CHECK_EQ(1, length);
   CHECK_EQ("0", buffer.start());


### PR DESCRIPTION
AddressSanitizer, `-DNDEBUG` build:

    ==ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 1
        #0 DigitGen fast-dtoa.cc:387
        #1 Grisu3 fast-dtoa.cc:579
        #2 FastDtoa fast-dtoa.cc:649
        #3 DoubleToStringConverter::DoubleToAscii double-to-string.cc:427
    0 bytes after 10-byte region

Reached from `DoubleToAscii(DBL_MIN, SHORTEST_SINGLE, 0, buf, 10, ...)`, a conforming call: the header only forbids `static_cast<float>(v)` being NaN or +/-Infinity, and a positive double below the smallest float (0 < v < 2^-150, e.g. `DBL_MIN` or `5e-324`) casts to a finite +0.0f. Grisu3 then takes the shortest-single boundaries from `Single(0.0f).NormalizedBoundaries()`, violating its value > 0 precondition, so DigitGen emits about 20 digits at the double magnitude into the 10-byte (`kBase10MaximalLengthSingle + 1`) buffer.

The existing zero special-case only catches an exact double zero. Extend it so SHORTEST_SINGLE also emits "0" when the value rounds to a single zero, the way an actual single zero already renders. Regression case added beside the existing SHORTEST_SINGLE tests in test-dtoa.cc.