### PR TITLE
Remove the BitSize helper template to fix -Wunused-template with clang 23

### DIFF
--- a/double-conversion/bignum.cc
+++ b/double-conversion/bignum.cc
@@ -45,15 +45,9 @@ const Bignum::Chunk& Bignum::RawBigit(const int index) const {
 }
 
 
-template<typename S>
-static int BitSize(const S value) {
-  (void) value;  // Mark variable as used.
-  return 8 * sizeof(value);
-}
-
 // Guaranteed to lie in one Bigit.
 void Bignum::AssignUInt16(const uint16_t value) {
-  DOUBLE_CONVERSION_ASSERT(kBigitSize >= BitSize(value));
+  DOUBLE_CONVERSION_ASSERT(kBigitSize >= 8 * sizeof(value));
   Zero();
   if (value > 0) {
     RawBigit(0) = value;


### PR DESCRIPTION
`BitSize` in `bignum.cc` is only used inside `DOUBLE_CONVERSION_ASSERT`, so in builds where the assertion compiles to nothing it is an internal-linkage function template with no instantiations. clang 23.1.0 diagnoses that under `-Wall`:

```
double-conversion/bignum.cc:49:12: error: unused function template 'BitSize' [-Werror,-Wunused-template]
```

which breaks `-Werror` builds (seen building Firefox, which vendors double-conversion). The helper computes `8 * sizeof(value)`, so inline that into the single assertion and drop the template. Same spirit as #56 for `Min`/`Max`.